### PR TITLE
Fix Android Makefile relative paths

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -1,22 +1,22 @@
 cmake_minimum_required(VERSION 3.9.0)
 
 # Needed to locate double-conversion src correctly for folly includes
-#execute_process (COMMAND ln "-s" "src" "../../react-native/third-party/double-conversion-1.1.6/double-conversion")
+#execute_process (COMMAND ln "-s" "src" "../../../react-native/third-party/double-conversion-1.1.6/double-conversion")
 
 add_subdirectory(./MMKV/Core Core)
 
 include_directories(
         ./MMKV/Core
-        ../node_modules/react-native/React
-        ../node_modules/react-native/React/Base
-        ../node_modules/react-native/ReactCommon/jsi
+        ../../../node_modules/react-native/React
+        ../../../node_modules/react-native/React/Base
+        ../../../node_modules/react-native/ReactCommon/jsi
 )
 
 add_library(cpp  # <-- Library name
         SHARED
         #MMKV/Core # <-- EXCLUDE_FROM_ALL
         # Provides a relative path to your source file(s).
-        ../node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp
+        ../../../node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp
         cpp-adapter.cpp
 )
 


### PR DESCRIPTION
Relative make paths were incorrect and causing an Android build error. Updated that to have the correct relative path.

`* What went wrong:
Execution failed for task ':react-native-mmkv:generateJsonModelDebug'.
> /Users/***/Developer/***/node_modules/react-native-mmkv/android/CMakeLists.txt : C/C++ debug|armeabi-v7a : CMake Error at /Users/***/Developer/***/node_modules/react-native-mmkv/android/CMakeLists.txt:15 (add_library):
    Cannot find source file:

      ../node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp

    Tried extensions .c .C .c++ .cc .cpp .cxx .m .M .mm .h .hh .h++ .hm .hpp
    .hxx .in .txx


* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 15s`