### PR TITLE
Android .aar

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "MMKV"]
+	path = MMKV
+	url = https://github.com/Tencent/MMKV.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "android/MMKV"]
-	path = android/MMKV
-	url = https://github.com/Tencent/MMKV.git

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.9.0)
 
-add_subdirectory(./MMKV/Core Core)
+add_subdirectory(../MMKV/Core Core)
 
 include_directories(
-        ./MMKV/Core
+        ../MMKV/Core
         ../../react-native/React
         ../../react-native/React/Base
         ../../react-native/ReactCommon/jsi
@@ -11,7 +11,6 @@ include_directories(
 
 add_library(cpp  # <-- Library name
         SHARED
-        #MMKV/Core # <-- EXCLUDE_FROM_ALL
         # Provides a relative path to your source file(s).
         ../../react-native/ReactCommon/jsi/jsi/jsi.cpp
         cpp-adapter.cpp

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mmkv",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mmkv",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mmkv",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mmkv",
-  "version": "0.1.8",
+  "version": "0.1.9-alpha",
   "description": "An efficient, small mobile key-value storage framework developed by WeChat. Works on Android and iOS.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mmkv",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "An efficient, small mobile key-value storage framework developed by WeChat. Works on Android and iOS.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -9,8 +9,7 @@
   "files": [
     "android/src",
     "android/build.gradle",
-    "android/gradle.properties",
-    "lib/aar",
+    "android/android.aar",
     "lib/commonjs",
     "lib/module",
     "lib/typescript",
@@ -29,7 +28,8 @@
     "release": "release-it",
     "example": "yarn --cwd example",
     "pods": "cd example && pod-install --quiet",
-    "bootstrap": "yarn example && yarn && yarn pods"
+    "bootstrap": "yarn example && yarn && yarn pods",
+    "prepack": "rm -rf android-tmp && mv android android-tmp && mv lib/aar android && cp android-tmp/src android/src"
   },
   "keywords": [
     "react-native",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
   "name": "react-native-mmkv",
-  "version": "0.1.9-alpha",
+  "version": "0.1.9",
   "description": "An efficient, small mobile key-value storage framework developed by WeChat. Works on Android and iOS.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
   "types": "lib/typescript/index.d.ts",
   "react-native": "lib/module/index",
   "files": [
+    "android/src",
+    "android/build.gradle",
+    "android/gradle.properties",
     "lib/aar",
     "lib/commonjs",
     "lib/module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mmkv",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "An efficient, small mobile key-value storage framework developed by WeChat. Works on Android and iOS.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -7,15 +7,10 @@
   "types": "lib/typescript/index.d.ts",
   "react-native": "lib/module/index",
   "files": [
+    "lib/aar",
     "lib/commonjs",
     "lib/module",
     "lib/typescript",
-    "android/build.gradle",
-    "android/MMKV/Core",
-    "android/gradle.properties",
-    "android/src",
-    "android/CMakeLists.txt",
-    "android/cpp-adapter.cpp",
     "ios/**/*.h",
     "ios/**/*.m",
     "ios/**/*.mm",
@@ -128,6 +123,7 @@
     "source": "src",
     "output": "lib",
     "targets": [
+      "aar",
       "commonjs",
       "module",
       [

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "example": "yarn --cwd example",
     "pods": "cd example && pod-install --quiet",
     "bootstrap": "yarn example && yarn && yarn pods",
-    "prepack": "rm -rf android-tmp && mv android android-tmp && mv lib/aar android && cp android-tmp/src android/src"
+    "prepack": "rm -rf android-tmp && mv android android-tmp && mv lib/aar android && cp -r android-tmp/src android/src",
+    "postpack": "rm -rf android && mv android-tmp android"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
Build a precompiled .aar file so you don't have to build the native C++ files anymore.

* Increases compilation time
* You don't need NDK installed
* Fixes #4 