### PR TITLE
Add set/get support for objects

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,10 @@ export const MMKV = {
   /**
    * Set a value for the given `key`.
    */
-  set: g.mmkvSet as (value: boolean | string | number, key: string) => void,
+  set: g.mmkvSet as (
+    value: boolean | string | number | Record<string, unknown>,
+    key: string
+  ) => void,
   /**
    * Get a boolean value for the given `key`.
    *
@@ -26,6 +29,14 @@ export const MMKV = {
    * @default 0
    */
   getNumber: g.mmkvGetNumber as (key: string) => number,
+  /**
+   * Get an object value for the given `key`.
+   *
+   * @default undefined
+   */
+  getObject: g.mmkvGetObject as (
+    key: string
+  ) => Record<string, unknown> | undefined,
   /**
    * Delete the given `key`.
    */


### PR DESCRIPTION
Adds support for:

```ts
const user = {
  username: 'Marc',
  age: 20
}

MMKV.set(user, 'user')
```

and

```ts
const user = MMKV.get('user') // --> { username: 'Marc', age: 20 }
```

This is very WIP and I'm not sure if it even works since I think MMKV (protobuf) has to know the size of the object it should retrieve.

Closes #2 