### PR TITLE
fix: Fix race condition crash on iOS

### DIFF
--- a/ios/Mmkv.mm
+++ b/ios/Mmkv.mm
@@ -115,18 +115,26 @@ static void install(jsi::Runtime & jsiRuntime)
     jsiRuntime.global().setProperty(jsiRuntime, "mmkvGetAllKeys", std::move(mmkvGetAllKeys));
 }
 
-- (void)setBridge:(RCTBridge *)bridge
+- (void)setup
 {
-    _bridge = bridge;
-    _setBridgeOnMainQueue = RCTIsMainQueue();
-
     RCTCxxBridge *cxxBridge = (RCTCxxBridge *)self.bridge;
     if (!cxxBridge.runtime) {
+        // retry 10ms later
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.001 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+            [self setup];
+        });
         return;
     }
 
     [MMKV initializeMMKV:nil];
     install(*(jsi::Runtime *)cxxBridge.runtime);
+}
+
+- (void)setBridge:(RCTBridge *)bridge
+{
+    _bridge = bridge;
+    _setBridgeOnMainQueue = RCTIsMainQueue();
+    [self setup];
 }
 
 - (void)invalidate {

--- a/ios/Mmkv.mm
+++ b/ios/Mmkv.mm
@@ -119,7 +119,7 @@ static void install(jsi::Runtime & jsiRuntime)
 {
     RCTCxxBridge *cxxBridge = (RCTCxxBridge *)self.bridge;
     if (!cxxBridge.runtime) {
-        // retry 10ms later
+        // retry 10ms later - THIS IS A WACK WORKAROUND. wait for TurboModules to land.
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.001 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
             [self setup];
         });


### PR DESCRIPTION
fixes #24 

this is a temporary fix to avoid a `setBridge:` race condition on iOS and will be fully fixed when TurboModules land