### PR TITLE
Add clearAll

### DIFF
--- a/android/cpp-adapter.cpp
+++ b/android/cpp-adapter.cpp
@@ -101,6 +101,16 @@ void install(jsi::Runtime& jsiRuntime) {
         return array;
     });
     jsiRuntime.global().setProperty(jsiRuntime, "mmkvGetAllKeys", std::move(mmkvGetAllKeys));
+
+    // MMKV.clearAll()
+    auto mmkvClearAll = jsi::Function::createFromHostFunction(jsiRuntime,
+                                                              jsi::PropNameID::forAscii(jsiRuntime, "mmkvClearAll"),
+                                                              0,
+                                                              [](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
+        MMKV::defaultMMKV()->clearAll();
+        return jsi::Value::undefined();
+    });
+    jsiRuntime.global().setProperty(jsiRuntime, "mmkvClearAll", std::move(mmkvClearAll));
 }
 
 std::string jstringToStdString(JNIEnv *env, jstring jStr) {

--- a/ios/Mmkv.mm
+++ b/ios/Mmkv.mm
@@ -113,6 +113,16 @@ static void install(jsi::Runtime & jsiRuntime)
         return convertNSArrayToJSIArray(runtime, keys);
     });
     jsiRuntime.global().setProperty(jsiRuntime, "mmkvGetAllKeys", std::move(mmkvGetAllKeys));
+
+    // MMKV.clearAll()
+    auto mmkvClearAll = jsi::Function::createFromHostFunction(jsiRuntime,
+                                                              jsi::PropNameID::forAscii(jsiRuntime, "mmkvClearAll"),
+                                                              0,
+                                                              [](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
+        [MMKV.defaultMMKV clearAll];
+        return jsi::Value::undefined();
+    });
+    jsiRuntime.global().setProperty(jsiRuntime, "mmkvClearAll", std::move(mmkvClearAll));
 }
 
 - (void)setBridge:(RCTBridge *)bridge

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,4 +36,8 @@ export const MMKV = {
    * @default []
    */
   getAllKeys: g.mmkvGetAllKeys as () => string[],
+  /**
+   * Delete all keys.
+   */
+  clearAll: g.mmkvClearAll as () => void,
 };


### PR DESCRIPTION
Adds the clear all method to delete all keys. This avoid having to loop through all keys and call delete.