### PR TITLE
feat: support multiple instances

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(mmkvnative  # <-- Library name
         # Provides a relative path to your source file(s).
         ../../react-native/ReactCommon/jsi/jsi/jsi.cpp
         cpp-adapter.cpp
+        MmkvBinding.cpp
 )
 
 set_target_properties(

--- a/android/MmkvBinding.cpp
+++ b/android/MmkvBinding.cpp
@@ -1,0 +1,123 @@
+#include "MmkvBinding.h"
+#include "MMKV.h"
+
+#include <jsi/jsi.h>
+
+using namespace facebook;
+
+namespace react {
+namespace mmkv {
+
+MmkvBinding::MmkvBinding(MMKV *mmkv) : mmkv_(mmkv) {}
+
+jsi::Value MmkvBinding::get(jsi::Runtime &runtime, jsi::PropNameID const &name) {
+    auto methodName = name.utf8(runtime);
+    auto mmkv = mmkv_;
+
+    if (methodName == "getString") {
+        // MMKV.getString(key: string)
+        return jsi::Function::createFromHostFunction(runtime,
+                                                     name,
+                                                     1,  // key
+                                                     [mmkv](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
+            if (!arguments[0].isString()) throw jsi::JSError(runtime, "First argument ('key') has to be of type string!");
+            auto keyName = arguments[0].getString(runtime).utf8(runtime);
+
+            std::string result;
+            bool hasValue = mmkv->getString(keyName, result);
+            if (hasValue)
+                return jsi::Value(runtime, jsi::String::createFromUtf8(runtime, result));
+            else
+                return jsi::Value::undefined();
+        });
+    }
+    if (methodName == "set") {
+        // MMKV.set(key: string, value: string | number | bool)
+        return jsi::Function::createFromHostFunction(runtime,
+                                                     name,
+                                                     2,  // key, value
+                                                     [mmkv](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
+            if (!arguments[0].isString()) throw jsi::JSError(runtime, "MMKV::set: First argument ('key') has to be of type string!");
+            auto keyName = arguments[0].getString(runtime).utf8(runtime);
+
+            if (arguments[1].isBool()) {
+                mmkv->set(arguments[1].getBool(), keyName);
+            } else if (arguments[1].isNumber()) {
+                mmkv->set(arguments[1].getNumber(), keyName);
+            } else if (arguments[1].isString()) {
+                auto stringValue = arguments[1].getString(runtime).utf8(runtime);
+                mmkv->set(stringValue, keyName);
+            } else {
+                throw jsi::JSError(runtime, "MMKV::set: 'value' argument is not of type bool, number or string!");
+            }
+            return jsi::Value::undefined();
+        });
+    }
+    if (methodName == "getNumber") {
+        // MMKV.getNumber(key: string)
+        return jsi::Function::createFromHostFunction(runtime,
+                                                     name,
+                                                     1,  // key
+                                                     [mmkv](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
+            if (!arguments[0].isString()) throw jsi::JSError(runtime, "First argument ('key') has to be of type string!");
+            auto keyName = arguments[0].getString(runtime).utf8(runtime);
+
+            auto value = mmkv->getDouble(keyName);
+            return jsi::Value(value);
+        });
+    }
+    if (methodName == "getBoolean") {
+        // MMKV.getBoolean(key: string)
+        return jsi::Function::createFromHostFunction(runtime,
+                                                     name,
+                                                     1,  // key
+                                                     [mmkv](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
+            if (!arguments[0].isString()) throw jsi::JSError(runtime, "First argument ('key') has to be of type string!");
+            auto keyName = arguments[0].getString(runtime).utf8(runtime);
+
+            auto value = mmkv->getBool(keyName);
+            return jsi::Value(value);
+        });
+    }
+    if (methodName == "delete") {
+        // MMKV.delete(key: string)
+        return jsi::Function::createFromHostFunction(runtime,
+                                                     name,
+                                                     1,  // key
+                                                     [mmkv](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
+            if (!arguments[0].isString()) throw jsi::JSError(runtime, "First argument ('key') has to be of type string!");
+            auto keyName = arguments[0].getString(runtime).utf8(runtime);
+
+            mmkv->removeValueForKey(keyName);
+            return jsi::Value::undefined();
+        });
+    }
+    if (methodName == "getAllKeys") {
+        // MMKV.getAllKeys()
+        return jsi::Function::createFromHostFunction(runtime,
+                                                     name,
+                                                     0,
+                                                     [mmkv](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
+            auto keys = mmkv->allKeys();
+            auto array = jsi::Array(runtime, keys.size());
+            for (int i = 0; i < keys.size(); i++) {
+                array.setValueAtIndex(runtime, i, keys[i]);
+            }
+            return array;
+        });
+    }
+    if (methodName == "clearAll") {
+        // MMKV.clearAll()
+        return jsi::Function::createFromHostFunction(runtime,
+                                                     name,
+                                                     0,
+                                                     [mmkv](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
+            mmkv->clearAll();
+            return jsi::Value::undefined();
+        });
+    }
+    return jsi::Value::undefined();
+}
+
+} // namespace mmkv
+} // namespace react

--- a/android/MmkvBinding.h
+++ b/android/MmkvBinding.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <jsi/jsi.h>
+
+using namespace facebook;
+
+class MMKV;
+
+namespace react {
+namespace mmkv {
+
+class MmkvBinding : public jsi::HostObject {
+    public:
+        MmkvBinding(MMKV *mmkv);
+
+        /*
+        * `jsi::HostObject` specific overloads.
+        */
+        jsi::Value get(jsi::Runtime &runtime, jsi::PropNameID const &name) override;
+
+    private:
+        MMKV *mmkv_;
+};
+
+} // namespace mmkv
+} // namespace react

--- a/android/cpp-adapter.cpp
+++ b/android/cpp-adapter.cpp
@@ -1,116 +1,23 @@
 #include <jni.h>
 #include <jsi/jsi.h>
 #include "MMKV.h"
+#include "MmkvBinding.h"
 
 using namespace facebook;
 
 void install(jsi::Runtime& jsiRuntime) {
-    // MMKV.set(key: string, value: string | number | bool)
-    auto mmkvSet = jsi::Function::createFromHostFunction(jsiRuntime,
-                                                         jsi::PropNameID::forAscii(jsiRuntime, "mmkvSet"),
-                                                         2,  // key, value
-                                                         [](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
-        if (!arguments[0].isString()) throw jsi::JSError(runtime, "MMKV::set: First argument ('key') has to be of type string!");
-        auto keyName = arguments[0].getString(runtime).utf8(runtime);
-
-        if (arguments[1].isBool()) {
-            MMKV::defaultMMKV()->set(arguments[1].getBool(), keyName);
-        } else if (arguments[1].isNumber()) {
-            MMKV::defaultMMKV()->set(arguments[1].getNumber(), keyName);
-        } else if (arguments[1].isString()) {
-            auto stringValue = arguments[1].getString(runtime).utf8(runtime);
-            MMKV::defaultMMKV()->set(stringValue, keyName);
-        } else {
-            throw jsi::JSError(runtime, "MMKV::set: 'value' argument is not of type bool, number or string!");
-        }
-        return jsi::Value::undefined();
-    });
-    jsiRuntime.global().setProperty(jsiRuntime, "mmkvSet", std::move(mmkvSet));
-
-
-    // MMKV.getBoolean(key: string)
-    auto mmkvGetBoolean = jsi::Function::createFromHostFunction(jsiRuntime,
-                                                                jsi::PropNameID::forAscii(jsiRuntime, "mmkvGetBoolean"),
-                                                                1,  // key
-                                                                [](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
-        if (!arguments[0].isString()) throw jsi::JSError(runtime, "First argument ('key') has to be of type string!");
-        auto keyName = arguments[0].getString(runtime).utf8(runtime);
-
-        auto value = MMKV::defaultMMKV()->getBool(keyName);
-        return jsi::Value(value);
-    });
-    jsiRuntime.global().setProperty(jsiRuntime, "mmkvGetBoolean", std::move(mmkvGetBoolean));
-
-
-    // MMKV.getString(key: string)
-    auto mmkvGetString = jsi::Function::createFromHostFunction(jsiRuntime,
-                                                               jsi::PropNameID::forAscii(jsiRuntime, "mmkvGetString"),
-                                                               1,  // key
-                                                               [](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
-        if (!arguments[0].isString()) throw jsi::JSError(runtime, "First argument ('key') has to be of type string!");
-        auto keyName = arguments[0].getString(runtime).utf8(runtime);
-
-        std::string result;
-        bool hasValue = MMKV::defaultMMKV()->getString(keyName, result);
-        if (hasValue)
-            return jsi::Value(runtime, jsi::String::createFromUtf8(runtime, result));
-        else
-            return jsi::Value::undefined();
-    });
-    jsiRuntime.global().setProperty(jsiRuntime, "mmkvGetString", std::move(mmkvGetString));
-
-
-    // MMKV.getNumber(key: string)
-    auto mmkvGetNumber = jsi::Function::createFromHostFunction(jsiRuntime,
-                                                               jsi::PropNameID::forAscii(jsiRuntime, "mmkvGetNumber"),
-                                                               1,  // key
-                                                               [](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
-        if (!arguments[0].isString()) throw jsi::JSError(runtime, "First argument ('key') has to be of type string!");
-        auto keyName = arguments[0].getString(runtime).utf8(runtime);
-
-        auto value = MMKV::defaultMMKV()->getDouble(keyName);
-        return jsi::Value(value);
-    });
-    jsiRuntime.global().setProperty(jsiRuntime, "mmkvGetNumber", std::move(mmkvGetNumber));
-
-
-    // MMKV.delete(key: string)
-    auto mmkvDelete = jsi::Function::createFromHostFunction(jsiRuntime,
-                                                            jsi::PropNameID::forAscii(jsiRuntime, "mmkvDelete"),
-                                                            1,  // key
+    auto mmkvWithID = jsi::Function::createFromHostFunction(jsiRuntime,
+                                                            jsi::PropNameID::forAscii(jsiRuntime, "mmkvWithID"),
+                                                            1,  // id
                                                             [](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
-        if (!arguments[0].isString()) throw jsi::JSError(runtime, "First argument ('key') has to be of type string!");
-        auto keyName = arguments[0].getString(runtime).utf8(runtime);
-
-        MMKV::defaultMMKV()->removeValueForKey(keyName);
-        return jsi::Value::undefined();
+        if (!arguments[0].isString() && !arguments[0].isNull()) throw jsi::JSError(runtime, "mmkvWithID: First argument ('id') has to be of type string or null.");
+        auto mmkv = arguments[0].isNull()
+          ? MMKV::defaultMMKV()
+          : MMKV::mmkvWithID(arguments[0].getString(runtime).utf8(runtime));
+        auto mmkvJsi = std::make_shared<react::mmkv::MmkvBinding>(std::move(mmkv));
+        return jsi::Object::createFromHostObject(runtime, mmkvJsi);
     });
-    jsiRuntime.global().setProperty(jsiRuntime, "mmkvDelete", std::move(mmkvDelete));
-
-
-    // MMKV.getAllKeys()
-    auto mmkvGetAllKeys = jsi::Function::createFromHostFunction(jsiRuntime,
-                                                                jsi::PropNameID::forAscii(jsiRuntime, "mmkvGetAllKeys"),
-                                                                0,
-                                                                [](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
-        auto keys = MMKV::defaultMMKV()->allKeys();
-        auto array = jsi::Array(runtime, keys.size());
-        for (int i = 0; i < keys.size(); i++) {
-            array.setValueAtIndex(runtime, i, keys[i]);
-        }
-        return array;
-    });
-    jsiRuntime.global().setProperty(jsiRuntime, "mmkvGetAllKeys", std::move(mmkvGetAllKeys));
-
-    // MMKV.clearAll()
-    auto mmkvClearAll = jsi::Function::createFromHostFunction(jsiRuntime,
-                                                              jsi::PropNameID::forAscii(jsiRuntime, "mmkvClearAll"),
-                                                              0,
-                                                              [](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
-        MMKV::defaultMMKV()->clearAll();
-        return jsi::Value::undefined();
-    });
-    jsiRuntime.global().setProperty(jsiRuntime, "mmkvClearAll", std::move(mmkvClearAll));
+    jsiRuntime.global().setProperty(jsiRuntime, "mmkvWithID", std::move(mmkvWithID));
 }
 
 std::string jstringToStdString(JNIEnv *env, jstring jStr) {

--- a/ios/Mmkv.mm
+++ b/ios/Mmkv.mm
@@ -1,5 +1,6 @@
 #import "Mmkv.h"
 #import "YeetJSIUtils.h"
+#import "MmkvBinding.h"
 
 #import <React/RCTBridge+Private.h>
 #import <React/RCTUtils.h>
@@ -19,110 +20,20 @@ RCT_EXPORT_MODULE()
     return YES;
 }
 
-
 static void install(jsi::Runtime & jsiRuntime)
 {
-    // MMKV.set(key: string, value: string | number | bool)
-    auto mmkvSet = jsi::Function::createFromHostFunction(jsiRuntime,
-                                                         jsi::PropNameID::forAscii(jsiRuntime, "mmkvSet"),
-                                                         2,  // key, value
-                                                         [](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
-        if (!arguments[0].isString()) throw jsi::JSError(runtime, "MMKV::set: First argument ('key') has to be of type string!");
-        auto keyName = convertJSIStringToNSString(runtime, arguments[0].getString(runtime));
-
-        if (arguments[1].isBool()) {
-            [MMKV.defaultMMKV setBool:arguments[1].getBool() forKey:keyName];
-        } else if (arguments[1].isNumber()) {
-            [MMKV.defaultMMKV setDouble:arguments[1].getNumber() forKey:keyName];
-        } else if (arguments[1].isString()) {
-            auto stringValue = convertJSIStringToNSString(runtime, arguments[1].getString(runtime));
-            [MMKV.defaultMMKV setString:stringValue forKey:keyName];
-        } else {
-            throw jsi::JSError(runtime, "MMKV::set: 'value' argument is not of type bool, number or string!");
-        }
-        return jsi::Value::undefined();
-    });
-    jsiRuntime.global().setProperty(jsiRuntime, "mmkvSet", std::move(mmkvSet));
-
-
-    // MMKV.getBoolean(key: string)
-    auto mmkvGetBoolean = jsi::Function::createFromHostFunction(jsiRuntime,
-                                                                jsi::PropNameID::forAscii(jsiRuntime, "mmkvGetBoolean"),
-                                                                1,  // key
-                                                                [](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
-        if (!arguments[0].isString()) throw jsi::JSError(runtime, "First argument ('key') has to be of type string!");
-
-        auto keyName = convertJSIStringToNSString(runtime, arguments[0].getString(runtime));
-        auto value = [MMKV.defaultMMKV getBoolForKey:keyName];
-        return jsi::Value(value);
-    });
-    jsiRuntime.global().setProperty(jsiRuntime, "mmkvGetBoolean", std::move(mmkvGetBoolean));
-
-
-    // MMKV.getString(key: string)
-    auto mmkvGetString = jsi::Function::createFromHostFunction(jsiRuntime,
-                                                               jsi::PropNameID::forAscii(jsiRuntime, "mmkvGetString"),
-                                                               1,  // key
-                                                               [](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
-        if (!arguments[0].isString()) throw jsi::JSError(runtime, "First argument ('key') has to be of type string!");
-
-        auto keyName = convertJSIStringToNSString(runtime, arguments[0].getString(runtime));
-        auto value = [MMKV.defaultMMKV getStringForKey:keyName];
-        if (value != nil)
-            return convertNSStringToJSIString(runtime, value);
-        else
-            return jsi::Value::undefined();
-    });
-    jsiRuntime.global().setProperty(jsiRuntime, "mmkvGetString", std::move(mmkvGetString));
-
-
-    // MMKV.getNumber(key: string)
-    auto mmkvGetNumber = jsi::Function::createFromHostFunction(jsiRuntime,
-                                                               jsi::PropNameID::forAscii(jsiRuntime, "mmkvGetNumber"),
-                                                               1,  // key
-                                                               [](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
-        if (!arguments[0].isString()) throw jsi::JSError(runtime, "First argument ('key') has to be of type string!");
-
-        auto keyName = convertJSIStringToNSString(runtime, arguments[0].getString(runtime));
-        auto value = [MMKV.defaultMMKV getDoubleForKey:keyName];
-        return jsi::Value(value);
-    });
-    jsiRuntime.global().setProperty(jsiRuntime, "mmkvGetNumber", std::move(mmkvGetNumber));
-
-
-    // MMKV.delete(key: string)
-    auto mmkvDelete = jsi::Function::createFromHostFunction(jsiRuntime,
-                                                            jsi::PropNameID::forAscii(jsiRuntime, "mmkvDelete"),
-                                                            1,  // key
+    auto mmkvWithID = jsi::Function::createFromHostFunction(jsiRuntime,
+                                                            jsi::PropNameID::forAscii(jsiRuntime, "mmkvWithID"),
+                                                            1,  // id
                                                             [](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
-        if (!arguments[0].isString()) throw jsi::JSError(runtime, "First argument ('key') has to be of type string!");
-
-        auto keyName = convertJSIStringToNSString(runtime, arguments[0].getString(runtime));
-        [MMKV.defaultMMKV removeValueForKey:keyName];
-        return jsi::Value::undefined();
+        if (!arguments[0].isString() && !arguments[0].isNull()) throw jsi::JSError(runtime, "mmkvWithID: First argument ('id') has to be of type string or null.");
+        auto mmkv = arguments[0].isNull()
+          ? MMKV.defaultMMKV
+          : [MMKV mmkvWithID:convertJSIStringToNSString(runtime, arguments[0].getString(runtime))];
+        auto mmkvJsi = std::make_shared<react::mmkv::MmkvBinding>(std::move(mmkv));
+        return jsi::Object::createFromHostObject(runtime, mmkvJsi);
     });
-    jsiRuntime.global().setProperty(jsiRuntime, "mmkvDelete", std::move(mmkvDelete));
-
-
-    // MMKV.getAllKeys()
-    auto mmkvGetAllKeys = jsi::Function::createFromHostFunction(jsiRuntime,
-                                                                jsi::PropNameID::forAscii(jsiRuntime, "mmkvGetAllKeys"),
-                                                                0,
-                                                                [](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
-        auto keys = [MMKV.defaultMMKV allKeys];
-        return convertNSArrayToJSIArray(runtime, keys);
-    });
-    jsiRuntime.global().setProperty(jsiRuntime, "mmkvGetAllKeys", std::move(mmkvGetAllKeys));
-
-    // MMKV.clearAll()
-    auto mmkvClearAll = jsi::Function::createFromHostFunction(jsiRuntime,
-                                                              jsi::PropNameID::forAscii(jsiRuntime, "mmkvClearAll"),
-                                                              0,
-                                                              [](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
-        [MMKV.defaultMMKV clearAll];
-        return jsi::Value::undefined();
-    });
-    jsiRuntime.global().setProperty(jsiRuntime, "mmkvClearAll", std::move(mmkvClearAll));
+    jsiRuntime.global().setProperty(jsiRuntime, "mmkvWithID", std::move(mmkvWithID));
 }
 
 - (void)setup
@@ -145,10 +56,6 @@ static void install(jsi::Runtime & jsiRuntime)
     _bridge = bridge;
     _setBridgeOnMainQueue = RCTIsMainQueue();
     [self setup];
-}
-
-- (void)invalidate {
-    [MMKV.defaultMMKV close];
 }
 
 @end

--- a/ios/Mmkv.xcodeproj/project.pbxproj
+++ b/ios/Mmkv.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0CFFFB9926996DF9002DC43F /* MmkvBinding.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0CFFFB9726996DF9002DC43F /* MmkvBinding.mm */; };
 		5E555C0D2413F4C50049A1A2 /* Mmkv.mm in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* Mmkv.mm */; };
 		B8CC270225E65597009808A2 /* YeetJSIUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = B8CC270125E65597009808A2 /* YeetJSIUtils.mm */; };
 /* End PBXBuildFile section */
@@ -24,6 +25,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0CFFFB9726996DF9002DC43F /* MmkvBinding.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MmkvBinding.mm; sourceTree = "<group>"; };
+		0CFFFB9826996DF9002DC43F /* MmkvBinding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MmkvBinding.h; sourceTree = "<group>"; };
 		134814201AA4EA6300B7C361 /* libMmkv.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMmkv.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3E7B5891CC2AC0600A0062D /* Mmkv.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Mmkv.mm; sourceTree = "<group>"; };
 		B865949C25E63C5C002102DB /* Mmkv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Mmkv.h; sourceTree = "<group>"; };
@@ -57,6 +60,8 @@
 				B8CC270125E65597009808A2 /* YeetJSIUtils.mm */,
 				B865949C25E63C5C002102DB /* Mmkv.h */,
 				B3E7B5891CC2AC0600A0062D /* Mmkv.mm */,
+				0CFFFB9826996DF9002DC43F /* MmkvBinding.h */,
+				0CFFFB9726996DF9002DC43F /* MmkvBinding.mm */,
 				134814211AA4EA7D00B7C361 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -120,6 +125,7 @@
 			files = (
 				5E555C0D2413F4C50049A1A2 /* Mmkv.mm in Sources */,
 				B8CC270225E65597009808A2 /* YeetJSIUtils.mm in Sources */,
+				0CFFFB9926996DF9002DC43F /* MmkvBinding.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/MmkvBinding.h
+++ b/ios/MmkvBinding.h
@@ -1,0 +1,24 @@
+#import <jsi/jsi.h>
+
+@class MMKV;
+
+using namespace facebook;
+
+namespace react {
+namespace mmkv {
+
+class MmkvBinding : public jsi::HostObject {
+    public:
+        MmkvBinding(MMKV *mmkv);
+
+        /*
+        * `jsi::HostObject` specific overloads.
+        */
+        jsi::Value get(jsi::Runtime &runtime, jsi::PropNameID const &name) override;
+
+    private:
+        MMKV *mmkv_;
+};
+
+} // namespace mmkv
+} // namespace react

--- a/ios/MmkvBinding.mm
+++ b/ios/MmkvBinding.mm
@@ -1,0 +1,118 @@
+#import "MmkvBinding.h"
+#import "YeetJSIUtils.h"
+
+#import <MMKV/MMKV.h>
+
+using namespace facebook;
+
+namespace react {
+namespace mmkv {
+
+MmkvBinding::MmkvBinding(MMKV *mmkv) : mmkv_(mmkv) {}
+
+jsi::Value MmkvBinding::get(jsi::Runtime &runtime, jsi::PropNameID const &name) {
+    auto methodName = name.utf8(runtime);
+    auto mmkv = mmkv_;
+
+    if (methodName == "getString") {
+        // MMKV.getString(key: string)
+        return jsi::Function::createFromHostFunction(runtime,
+                                                     name,
+                                                     1,  // key
+                                                     [mmkv](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
+            if (!arguments[0].isString()) throw jsi::JSError(runtime, "First argument ('key') has to be of type string!");
+
+            auto keyName = convertJSIStringToNSString(runtime, arguments[0].getString(runtime));
+            auto value = [mmkv getStringForKey:keyName];
+            if (value != nil)
+                return convertNSStringToJSIString(runtime, value);
+            else
+                return jsi::Value::undefined();
+        });
+    }
+    if (methodName == "set") {
+        // MMKV.set(key: string, value: string | number | bool)
+        return jsi::Function::createFromHostFunction(runtime,
+                                                     name,
+                                                     2,  // key, value
+                                                     [mmkv](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
+            if (!arguments[0].isString()) throw jsi::JSError(runtime, "MMKV::set: First argument ('key') has to be of type string!");
+            auto keyName = convertJSIStringToNSString(runtime, arguments[0].getString(runtime));
+
+            if (arguments[1].isBool()) {
+                [mmkv setBool:arguments[1].getBool() forKey:keyName];
+            } else if (arguments[1].isNumber()) {
+                [mmkv setDouble:arguments[1].getNumber() forKey:keyName];
+            } else if (arguments[1].isString()) {
+                auto stringValue = convertJSIStringToNSString(runtime, arguments[1].getString(runtime));
+                [mmkv setString:stringValue forKey:keyName];
+            } else {
+                throw jsi::JSError(runtime, "MMKV::set: 'value' argument is not of type bool, number or string!");
+            }
+            return jsi::Value::undefined();
+        });
+    }
+    if (methodName == "getNumber") {
+        // MMKV.getNumber(key: string)
+        return jsi::Function::createFromHostFunction(runtime,
+                                                     name,
+                                                     1,  // key
+                                                     [mmkv](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
+            if (!arguments[0].isString()) throw jsi::JSError(runtime, "First argument ('key') has to be of type string!");
+
+            auto keyName = convertJSIStringToNSString(runtime, arguments[0].getString(runtime));
+            auto value = [mmkv getDoubleForKey:keyName];
+            return jsi::Value(value);
+        });
+    }
+    if (methodName == "getBoolean") {
+        // MMKV.getBoolean(key: string)
+        return jsi::Function::createFromHostFunction(runtime,
+                                                     name,
+                                                     1,  // key
+                                                     [mmkv](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
+            if (!arguments[0].isString()) throw jsi::JSError(runtime, "First argument ('key') has to be of type string!");
+
+            auto keyName = convertJSIStringToNSString(runtime, arguments[0].getString(runtime));
+            auto value = [mmkv getBoolForKey:keyName];
+            return jsi::Value(value);
+        });
+    }
+    if (methodName == "delete") {
+        // MMKV.delete(key: string)
+        return jsi::Function::createFromHostFunction(runtime,
+                                                     name,
+                                                     1,  // key
+                                                     [mmkv](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
+            if (!arguments[0].isString()) throw jsi::JSError(runtime, "First argument ('key') has to be of type string!");
+
+            auto keyName = convertJSIStringToNSString(runtime, arguments[0].getString(runtime));
+            [mmkv removeValueForKey:keyName];
+            return jsi::Value::undefined();
+        });
+    }
+    if (methodName == "getAllKeys") {
+        // MMKV.getAllKeys()
+        return jsi::Function::createFromHostFunction(runtime,
+                                                     name,
+                                                     0,
+                                                     [mmkv](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
+            auto keys = [mmkv allKeys];
+            return convertNSArrayToJSIArray(runtime, keys);
+        });
+    }
+    if (methodName == "clearAll") {
+        // MMKV.clearAll()
+        return jsi::Function::createFromHostFunction(runtime,
+                                                     name,
+                                                     0,
+                                                     [mmkv](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
+            [mmkv clearAll];
+            return jsi::Value::undefined();
+        });
+    }
+    return jsi::Value::undefined();
+}
+
+} // namespace mmkv
+} // namespace react

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,43 +1,52 @@
 const g = global as any;
 
-/**
- * MMKV is an efficient, small mobile key-value storage framework developed by WeChat.
- */
-export const MMKV = {
+export interface MMKVInstance {
   /**
    * Set a value for the given `key`.
    */
-  set: g.mmkvSet as (key: string, value: boolean | string | number) => void,
+  set: (key: string, value: boolean | string | number) => void;
   /**
    * Get a boolean value for the given `key`.
    *
    * @default false
    */
-  getBoolean: g.mmkvGetBoolean as (key: string) => boolean,
+  getBoolean: (key: string) => boolean;
   /**
    * Get a string value for the given `key`.
    *
    * @default undefined
    */
-  getString: g.mmkvGetString as (key: string) => string | undefined,
+  getString: (key: string) => string | undefined;
   /**
    * Get a number value for the given `key`.
    *
    * @default 0
    */
-  getNumber: g.mmkvGetNumber as (key: string) => number,
+  getNumber: (key: string) => number;
   /**
    * Delete the given `key`.
    */
-  delete: g.mmkvDelete as (key: string) => void,
+  delete: (key: string) => void;
   /**
    * Get all keys.
    *
    * @default []
    */
-  getAllKeys: g.mmkvGetAllKeys as () => string[],
+  getAllKeys: () => string[];
   /**
    * Delete all keys.
    */
-  clearAll: g.mmkvClearAll as () => void,
-};
+  clearAll: () => void;
+}
+
+/**
+ * Create an MMKV instance.
+ *
+ * @param id The unique ID of the MMKV instance or null for the default.
+ */
+export const mmkvWithID = g.mmkvWithID as (id: string | null) => MMKVInstance;
+
+/**
+ * MMKV is an efficient, small mobile key-value storage framework developed by WeChat.
+ */
+export const MMKV = mmkvWithID(null);


### PR DESCRIPTION
Add `mmkvWithID` to allow creating multiple instances. This function returns a `jsi::HostObject` that has all the methods previously exposed as global variables. The host object has a reference to its mmkv instance and uses that instead of the global instance. Passing null to `mmkvWithID` will use the default instance.