### PR TITLE
Renaming import from blacklist to exclusionList

### DIFF
--- a/example/metro.config.js
+++ b/example/metro.config.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const blacklist = require('metro-config/src/defaults/blacklist');
+const blacklist = require('metro-config/src/defaults/exclusionList');
 const escape = require('escape-string-regexp');
 const pak = require('../package.json');
 


### PR DESCRIPTION
`metro-config/src/defaults/blacklist` was renamed to `metro-config/src/defaults/exclusionList` in this commit: [facebook/metro@3e2d911](https://github.com/facebook/metro/commit/3e2d9116d8a7f2580dcda51990cca5b3d98a81ff#diff-a6e36af38cd6fde5360c601ce8f2f02e4e6b350b7fea9b0f049ab63f3b8f5709).

example project is not working because of this, the PR just fix it.