### PR TITLE
fix: Fix build

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.9.0)
 
 add_subdirectory(../MMKV/Core Core)
 
+set (PACKAGE_NAME "react-native-mmkv")
+set (BUILD_DIR ${CMAKE_SOURCE_DIR}/build)
+
 include_directories(
         ../MMKV/Core
         ../../react-native/React
@@ -11,8 +14,6 @@ include_directories(
 
 add_library(mmkvnative  # <-- Library name
         SHARED
-        # Provides a relative path to your source file(s).
-        ../../react-native/ReactCommon/jsi/jsi/jsi.cpp
         cpp-adapter.cpp
 )
 
@@ -23,15 +24,23 @@ set_target_properties(
         POSITION_INDEPENDENT_CODE ON
 )
 
+file (GLOB LIBRN_DIR "${BUILD_DIR}/react-native-0*/jni/${ANDROID_ABI}")
 
 find_library(
-        log-lib # Sets the name of the path variable.
+        log-lib
         log
+)
+find_library(
+        REACT_NATIVE_JNI_LIB
+        reactnativejni
+        PATHS ${LIBRN_DIR}
+        NO_CMAKE_FIND_ROOT_PATH
 )
 
 target_link_libraries(
         mmkvnative
         core
         ${log-lib}
+        ${REACT_NATIVE_JNI_LIB}
         android
 )

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -12,13 +12,13 @@ include_directories(
         ../../react-native/ReactCommon/jsi
 )
 
-add_library(mmkvnative  # <-- Library name
+add_library(reactnativemmkv  # <-- Library name
         SHARED
         cpp-adapter.cpp
 )
 
 set_target_properties(
-        mmkvnative PROPERTIES
+        reactnativemmkv PROPERTIES
         CXX_STANDARD 17
         CXX_EXTENSIONS OFF
         POSITION_INDEPENDENT_CODE ON
@@ -38,7 +38,7 @@ find_library(
 )
 
 target_link_libraries(
-        mmkvnative
+        reactnativemmkv
         core
         ${log-lib}
         ${REACT_NATIVE_JNI_LIB}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.2.1'
+    classpath 'com.android.tools.build:gradle:4.2.1'
   }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.2.1'
+    classpath 'com.android.tools.build:gradle:3.2.1'
   }
 }
 
@@ -22,6 +22,7 @@ def getExtOrIntegerDefault(name) {
 android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
+  ndkVersion getExtOrDefault('ndkVersion')
 
   defaultConfig {
     minSdkVersion 16
@@ -55,6 +56,10 @@ android {
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_8
     targetCompatibility JavaVersion.VERSION_1_8
+  }
+
+  configurations {
+    extractJNI
   }
 }
 
@@ -132,4 +137,27 @@ repositories {
 dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
+
+  def rnAAR = fileTree("${rootDir}/../node_modules/react-native/android").matching({ it.include "**/**/*.aar" }).singleFile
+  extractJNI(files(rnAAR))
+}
+
+task extractJNIFiles {
+  doLast {
+    configurations.extractJNI.files.each {
+      def file = it.absoluteFile
+
+      copy {
+        from zipTree(file)
+        into "$buildDir/$file.name"
+        include "jni/**/*"
+      }
+    }
+  }
+}
+
+tasks.whenTaskAdded { task ->
+  if (task.name.contains('externalNativeBuild')) {
+    task.dependsOn(extractJNIFiles)
+  }
 }

--- a/android/src/main/java/com/reactnativemmkv/MmkvModule.java
+++ b/android/src/main/java/com/reactnativemmkv/MmkvModule.java
@@ -7,7 +7,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 
 public class MmkvModule extends ReactContextBaseJavaModule {
   static {
-    System.loadLibrary("mmkvnative");
+    System.loadLibrary("reactnativemmkv");
   }
 
   private static native void nativeInstall(long jsiPtr, String path);


### PR DESCRIPTION
what the f? I'm getting "stack overflow" exceptions and I have no idea why. Any call to the `jsiRuntime` apparently crashes. I have not touched anything there, so why the f does that crash? 

Since you guys said that v1.1.6 works, I checked out at the commit where 1.1.6 was released and tried running the example app. Same crash. How? Why?

```
2021-08-10 10:12:16.168 1476-1520/com.example.reactnativemmkv I/HermesVM: HermesRuntimeImpl::call: Unable to call function: stack overflow
2021-08-10 10:12:16.169 1476-1520/com.example.reactnativemmkv A/libc: /buildbot/src/googleplex-android/ndk-release-r20/external/libcxx/../../external/libcxxabi/src/abort_message.cpp:73: abort_message: assertion "terminating with uncaught exception of type facebook::jsi::JSINativeException: HermesRuntimeImpl::call: Unable to call function: stack overflow" failed
2021-08-10 10:12:16.169 1476-1520/com.example.reactnativemmkv A/libc: Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 1520 (create_react_co), pid 1476 (reactnativemmkv)
2021-08-10 10:12:16.213 1529-1529/? I/crash_dump32: obtaining output fd from tombstoned, type: kDebuggerdTombstone
2021-08-10 10:12:16.216 1909-1909/? I//system/bin/tombstoned: received crash request for pid 1520
2021-08-10 10:12:16.217 1529-1529/? I/crash_dump32: performing dump of process 1476 (target tid = 1520)
2021-08-10 10:12:16.224 1529-1529/? A/DEBUG: *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
2021-08-10 10:12:16.224 1529-1529/? A/DEBUG: Build fingerprint: 'google/sdk_gphone_x86/generic_x86:10/QSR1.190920.001/5891938:user/release-keys'
2021-08-10 10:12:16.224 1529-1529/? A/DEBUG: Revision: '0'
2021-08-10 10:12:16.224 1529-1529/? A/DEBUG: ABI: 'x86'
2021-08-10 10:12:16.224 1529-1529/? A/DEBUG: Timestamp: 2021-08-10 10:12:16+0200
2021-08-10 10:12:16.224 1529-1529/? A/DEBUG: pid: 1476, tid: 1520, name: create_react_co  >>> com.example.reactnativemmkv <<<
2021-08-10 10:12:16.224 1529-1529/? A/DEBUG: uid: 10136
2021-08-10 10:12:16.224 1529-1529/? A/DEBUG: signal 6 (SIGABRT), code -1 (SI_QUEUE), fault addr --------
2021-08-10 10:12:16.224 1529-1529/? A/DEBUG: Abort message: '/buildbot/src/googleplex-android/ndk-release-r20/external/libcxx/../../external/libcxxabi/src/abort_message.cpp:73: abort_message: assertion "terminating with uncaught exception of type facebook::jsi::JSINativeException: HermesRuntimeImpl::call: Unable to call function: stack overflow" failed'
2021-08-10 10:12:16.224 1529-1529/? A/DEBUG:     eax 00000000  ebx 000005c4  ecx 000005f0  edx 00000006
2021-08-10 10:12:16.224 1529-1529/? A/DEBUG:     edi e7c4633e  esi bf087710
2021-08-10 10:12:16.224 1529-1529/? A/DEBUG:     ebp eab88ad0  esp bf0876b8  eip eab88ad9
2021-08-10 10:12:16.262 1783-1532/? E/ResolverController: No valid NAT64 prefix (101, <unspecified>/0)
2021-08-10 10:12:16.307 1529-1529/? A/DEBUG: backtrace:
2021-08-10 10:12:16.307 1529-1529/? A/DEBUG:       #00 pc 00000ad9  [vdso] (__kernel_vsyscall+9)
2021-08-10 10:12:16.307 1529-1529/? A/DEBUG:       #01 pc 00092328  /apex/com.android.runtime/lib/bionic/libc.so (syscall+40) (BuildId: 76290498408016ad14f4b98c3ab6c65c)
2021-08-10 10:12:16.307 1529-1529/? A/DEBUG:       #02 pc 000ad651  /apex/com.android.runtime/lib/bionic/libc.so (abort+193) (BuildId: 76290498408016ad14f4b98c3ab6c65c)
2021-08-10 10:12:16.307 1529-1529/? A/DEBUG:       #03 pc 000adb88  /apex/com.android.runtime/lib/bionic/libc.so (__assert2+56) (BuildId: 76290498408016ad14f4b98c3ab6c65c)
2021-08-10 10:12:16.307 1529-1529/? A/DEBUG:       #04 pc 0009a874  /data/app/com.example.reactnativemmkv-w1vmlG_EnMHIJtbuVzpBHw==/lib/x86/libc++_shared.so (BuildId: e17c5af931f83c79fe858d7c19c030d4492104f4)
2021-08-10 10:12:16.307 1529-1529/? A/DEBUG:       #05 pc 0009aace  /data/app/com.example.reactnativemmkv-w1vmlG_EnMHIJtbuVzpBHw==/lib/x86/libc++_shared.so (BuildId: e17c5af931f83c79fe858d7c19c030d4492104f4)
2021-08-10 10:12:16.307 1529-1529/? A/DEBUG:       #06 pc 000b2789  /data/app/com.example.reactnativemmkv-w1vmlG_EnMHIJtbuVzpBHw==/lib/x86/libc++_shared.so (BuildId: e17c5af931f83c79fe858d7c19c030d4492104f4)
2021-08-10 10:12:16.308 1529-1529/? A/DEBUG:       #07 pc 000b1cbe  /data/app/com.example.reactnativemmkv-w1vmlG_EnMHIJtbuVzpBHw==/lib/x86/libc++_shared.so (BuildId: e17c5af931f83c79fe858d7c19c030d4492104f4)
2021-08-10 10:12:16.308 1529-1529/? A/DEBUG:       #08 pc 000b1c13  /data/app/com.example.reactnativemmkv-w1vmlG_EnMHIJtbuVzpBHw==/lib/x86/libc++_shared.so (__cxa_throw+115) (BuildId: e17c5af931f83c79fe858d7c19c030d4492104f4)
2021-08-10 10:12:16.308 1529-1529/? A/DEBUG:       #09 pc 0001fef6  /data/app/com.example.reactnativemmkv-w1vmlG_EnMHIJtbuVzpBHw==/lib/x86/libhermes.so (facebook::hermes::HermesRuntimeImpl::call(facebook::jsi::Function const&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)+1078) (BuildId: df8072863d396d57901d03a3514af58b13e5c804)
2021-08-10 10:12:16.308 1529-1529/? A/DEBUG:       #10 pc 0001854b  /data/app/com.example.reactnativemmkv-w1vmlG_EnMHIJtbuVzpBHw==/lib/x86/libhermes-executor-common-debug.so (BuildId: feaf1ba9dd56d4aee4cd4cd150b3e084685387b6)
2021-08-10 10:12:16.308 1529-1529/? A/DEBUG:       #11 pc 0004123e  /data/app/com.example.reactnativemmkv-w1vmlG_EnMHIJtbuVzpBHw==/lib/x86/libmmkvnative.so (facebook::jsi::Function::createFromHostFunction(facebook::jsi::Runtime&, facebook::jsi::PropNameID const&, unsigned int, std::__ndk1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>)+190) (BuildId: bebcb2f1c254db47c3fd84b1e5eb30b08c81d88f)
2021-08-10 10:12:16.308 1529-1529/? A/DEBUG:       #12 pc 0004072b  /data/app/com.example.reactnativemmkv-w1vmlG_EnMHIJtbuVzpBHw==/lib/x86/libmmkvnative.so (install(facebook::jsi::Runtime&)+171) (BuildId: bebcb2f1c254db47c3fd84b1e5eb30b08c81d88f)
2021-08-10 10:12:16.308 1529-1529/? A/DEBUG:       #13 pc 00042260  /data/app/com.example.reactnativemmkv-w1vmlG_EnMHIJtbuVzpBHw==/lib/x86/libmmkvnative.so (Java_com_reactnativemmkv_MmkvModule_nativeInstall+208) (BuildId: bebcb2f1c254db47c3fd84b1e5eb30b08c81d88f)
2021-08-10 10:12:16.308 1529-1529/? A/DEBUG:       #14 pc 00144f67  /apex/com.android.runtime/lib/libart.so (art_quick_generic_jni_trampoline+71) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.308 1529-1529/? A/DEBUG:       #15 pc 0013e9a2  /apex/com.android.runtime/lib/libart.so (art_quick_invoke_static_stub+418) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.308 1529-1529/? A/DEBUG:       #16 pc 00149a7a  /apex/com.android.runtime/lib/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+298) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.308 1529-1529/? A/DEBUG:       #17 pc 00332502  /apex/com.android.runtime/lib/libart.so (art::interpreter::ArtInterpreterToCompiledCodeBridge(art::Thread*, art::ArtMethod*, art::ShadowFrame*, unsigned short, art::JValue*)+386) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.308 1529-1529/? A/DEBUG:       #18 pc 0032c19c  /apex/com.android.runtime/lib/libart.so (bool art::interpreter::DoCall<false, false>(art::ArtMethod*, art::Thread*, art::ShadowFrame&, art::Instruction const*, unsigned short, art::JValue*)+988) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.308 1529-1529/? A/DEBUG:       #19 pc 00684d03  /apex/com.android.runtime/lib/libart.so (MterpInvokeStatic+643) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.308 1529-1529/? A/DEBUG:       #20 pc 001389a1  /apex/com.android.runtime/lib/libart.so (mterp_op_invoke_static+33) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.308 1529-1529/? A/DEBUG:       #21 pc 000004f0  [anon:dalvik-classes3.dex extracted in memory from /data/app/com.example.reactnativemmkv-w1vmlG_EnMHIJtbuVzpBHw==/base.apk!classes3.dex] (com.reactnativemmkv.MmkvModule.install+8)
2021-08-10 10:12:16.308 1529-1529/? A/DEBUG:       #22 pc 002f8e0a  /apex/com.android.runtime/lib/libart.so (_ZN3art11interpreterL7ExecuteEPNS_6ThreadERKNS_20CodeItemDataAccessorERNS_11ShadowFrameENS_6JValueEbb.llvm.12194892193087984976+298) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.308 1529-1529/? A/DEBUG:       #23 pc 002ffe19  /apex/com.android.runtime/lib/libart.so (art::interpreter::ArtInterpreterToInterpreterBridge(art::Thread*, art::CodeItemDataAccessor const&, art::ShadowFrame*, art::JValue*)+217) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.308 1529-1529/? A/DEBUG:       #24 pc 0032c17e  /apex/com.android.runtime/lib/libart.so (bool art::interpreter::DoCall<false, false>(art::ArtMethod*, art::Thread*, art::ShadowFrame&, art::Instruction const*, unsigned short, art::JValue*)+958) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.308 1529-1529/? A/DEBUG:       #25 pc 00684d03  /apex/com.android.runtime/lib/libart.so (MterpInvokeStatic+643) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.308 1529-1529/? A/DEBUG:       #26 pc 001389a1  /apex/com.android.runtime/lib/libart.so (mterp_op_invoke_static+33) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.308 1529-1529/? A/DEBUG:       #27 pc 00000462  [anon:dalvik-classes3.dex extracted in memory from /data/app/com.example.reactnativemmkv-w1vmlG_EnMHIJtbuVzpBHw==/base.apk!classes3.dex] (com.reactnativemmkv.MmkvModulePackage.getJSIModules+54)
2021-08-10 10:12:16.309 1529-1529/? A/DEBUG:       #28 pc 006837bc  /apex/com.android.runtime/lib/libart.so (MterpInvokeInterface+1980) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.309 1529-1529/? A/DEBUG:       #29 pc 00138a21  /apex/com.android.runtime/lib/libart.so (mterp_op_invoke_interface+33) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.309 1529-1529/? A/DEBUG:       #30 pc 001c8f34  [anon:dalvik-classes.dex extracted in memory from /data/app/com.example.reactnativemmkv-w1vmlG_EnMHIJtbuVzpBHw==/base.apk] (com.facebook.react.ReactInstanceManager.createReactContext+212)
2021-08-10 10:12:16.309 1529-1529/? A/DEBUG:       #31 pc 006845ac  /apex/com.android.runtime/lib/libart.so (MterpInvokeDirect+1324) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.309 1529-1529/? A/DEBUG:       #32 pc 00138921  /apex/com.android.runtime/lib/libart.so (mterp_op_invoke_direct+33) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.309 1529-1529/? A/DEBUG:       #33 pc 001c8e44  [anon:dalvik-classes.dex extracted in memory from /data/app/com.example.reactnativemmkv-w1vmlG_EnMHIJtbuVzpBHw==/base.apk] (com.facebook.react.ReactInstanceManager.access$1100)
2021-08-10 10:12:16.309 1529-1529/? A/DEBUG:       #34 pc 00684f6c  /apex/com.android.runtime/lib/libart.so (MterpInvokeStatic+1260) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.309 1529-1529/? A/DEBUG:       #35 pc 001389a1  /apex/com.android.runtime/lib/libart.so (mterp_op_invoke_static+33) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.309 1529-1529/? A/DEBUG:       #36 pc 001c8560  [anon:dalvik-classes.dex extracted in memory from /data/app/com.example.reactnativemmkv-w1vmlG_EnMHIJtbuVzpBHw==/base.apk] (com.facebook.react.ReactInstanceManager$5.run+140)
2021-08-10 10:12:16.309 1529-1529/? A/DEBUG:       #37 pc 006837bc  /apex/com.android.runtime/lib/libart.so (MterpInvokeInterface+1980) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.309 1529-1529/? A/DEBUG:       #38 pc 00138a21  /apex/com.android.runtime/lib/libart.so (mterp_op_invoke_interface+33) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.309 1529-1529/? A/DEBUG:       #39 pc 000ea918  /apex/com.android.runtime/javalib/core-oj.jar (java.lang.Thread.run+8)
2021-08-10 10:12:16.309 1529-1529/? A/DEBUG:       #40 pc 002f8e0a  /apex/com.android.runtime/lib/libart.so (_ZN3art11interpreterL7ExecuteEPNS_6ThreadERKNS_20CodeItemDataAccessorERNS_11ShadowFrameENS_6JValueEbb.llvm.12194892193087984976+298) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.309 1529-1529/? A/DEBUG:       #41 pc 002ffcc5  /apex/com.android.runtime/lib/libart.so (art::interpreter::EnterInterpreterFromEntryPoint(art::Thread*, art::CodeItemDataAccessor const&, art::ShadowFrame*)+181) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.309 1529-1529/? A/DEBUG:       #42 pc 0066fbd9  /apex/com.android.runtime/lib/libart.so (artQuickToInterpreterBridge+1209) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.309 1529-1529/? A/DEBUG:       #43 pc 0014503d  /apex/com.android.runtime/lib/libart.so (art_quick_to_interpreter_bridge+77) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.309 1529-1529/? A/DEBUG:       #44 pc 0013e7d2  /apex/com.android.runtime/lib/libart.so (art_quick_invoke_stub+338) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.309 1529-1529/? A/DEBUG:       #45 pc 00149a69  /apex/com.android.runtime/lib/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+281) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.309 1529-1529/? A/DEBUG:       #46 pc 0055a513  /apex/com.android.runtime/lib/libart.so (art::(anonymous namespace)::InvokeWithArgArray(art::ScopedObjectAccessAlreadyRunnable const&, art::ArtMethod*, art::(anonymous namespace)::ArgArray*, art::JValue*, char const*)+99) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.309 1529-1529/? A/DEBUG:       #47 pc 0055b91a  /apex/com.android.runtime/lib/libart.so (art::InvokeVirtualOrInterfaceWithJValues(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, _jmethodID*, jvalue const*)+474) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.309 1529-1529/? A/DEBUG:       #48 pc 005aaa51  /apex/com.android.runtime/lib/libart.so (art::Thread::CreateCallback(void*)+1585) (BuildId: 895645e5113da057f27d9b2ec11eb3bf)
2021-08-10 10:12:16.309 1529-1529/? A/DEBUG:       #49 pc 0011a8e5  /apex/com.android.runtime/lib/bionic/libc.so (__pthread_start(void*)+53) (BuildId: 76290498408016ad14f4b98c3ab6c65c)
2021-08-10 10:12:16.309 1529-1529/? A/DEBUG:       #50 pc 000af6a7  /apex/com.android.runtime/lib/bionic/libc.so (__start_thread+71) (BuildId: 76290498408016ad14f4b98c3ab6c65c)
2021-08-10 10:12:16.625 1909-1909/? E//system/bin/tombstoned: Tombstone written to: /data/tombstones/tombstone_06
```

## related issues

* #88 
* #98 
* #111 