### PR TITLE
feat: Web support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 * **High performance** because everything is **written in C++** (even the JS functions have C++ bodies!)
 * **~30x faster than AsyncStorage**
 * Uses [**JSI**](https://github.com/react-native-community/discussions-and-proposals/issues/91) instead of the "old" Bridge
+* **iOS**, **Android** and **Web** support
 
 ## Sponsors
 

--- a/example/src/Benchmarks.ts
+++ b/example/src/Benchmarks.ts
@@ -1,12 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { MMKV } from 'react-native-mmkv';
 
-declare global {
-  var performance: {
-    now: () => number;
-  };
-}
-
 const storage = new MMKV({ id: 'benchmark' });
 
 export const benchmarkAgainstAsyncStorage = async () => {

--- a/src/MMKV.ts
+++ b/src/MMKV.ts
@@ -120,11 +120,6 @@ export class MMKV implements MMKVInterface {
    * If no custom `id` is supplied, `'default'` will be used.
    */
   constructor(configuration: MMKVConfiguration = { id: 'mmkv.default' }) {
-    if (global.mmkvCreateNewInstance == null) {
-      throw new Error(
-        'Failed to create a new MMKV instance, the native initializer function does not exist. Is the native MMKV library correctly installed? Make sure to disable any remote debugger (e.g. Chrome) to use JSI!'
-      );
-    }
     this.id = configuration.id;
     this.nativeInstance = createMMKV(configuration);
     this.functionCache = {};

--- a/src/MMKV.ts
+++ b/src/MMKV.ts
@@ -93,14 +93,26 @@ export interface MMKVInterface {
   ) => Listener;
 }
 
+export type NativeMMKV = Pick<
+  MMKVInterface,
+  | 'clearAll'
+  | 'contains'
+  | 'delete'
+  | 'getAllKeys'
+  | 'getBoolean'
+  | 'getNumber'
+  | 'getString'
+  | 'set'
+>;
+
 const onValueChangedListeners = new Map<string, ((key: string) => void)[]>();
 
 /**
  * A single MMKV instance.
  */
 export class MMKV implements MMKVInterface {
-  private nativeInstance: MMKVInterface;
-  private functionCache: Partial<MMKVInterface>;
+  private nativeInstance: NativeMMKV;
+  private functionCache: Partial<NativeMMKV>;
   private id: string;
 
   /**
@@ -125,13 +137,13 @@ export class MMKV implements MMKVInterface {
     return onValueChangedListeners.get(this.id)!;
   }
 
-  private getFunctionFromCache<T extends keyof MMKVInterface>(
+  private getFunctionFromCache<T extends keyof NativeMMKV>(
     functionName: T
-  ): MMKVInterface[T] {
+  ): NativeMMKV[T] {
     if (this.functionCache[functionName] == null) {
       this.functionCache[functionName] = this.nativeInstance[functionName];
     }
-    return this.functionCache[functionName] as MMKVInterface[T];
+    return this.functionCache[functionName] as NativeMMKV[T];
   }
 
   private onValuesAboutToChange(keys: string[]) {

--- a/src/MMKV.ts
+++ b/src/MMKV.ts
@@ -1,4 +1,5 @@
 import { unstable_batchedUpdates } from 'react-native';
+import { createMMKV } from './createMMKV';
 
 interface Listener {
   remove: () => void;
@@ -92,13 +93,6 @@ export interface MMKVInterface {
   ) => Listener;
 }
 
-// global func declaration for JSI functions
-declare global {
-  function mmkvCreateNewInstance(
-    configuration: MMKVConfiguration
-  ): MMKVInterface;
-}
-
 const onValueChangedListeners = new Map<string, ((key: string) => void)[]>();
 
 /**
@@ -120,7 +114,7 @@ export class MMKV implements MMKVInterface {
       );
     }
     this.id = configuration.id;
-    this.nativeInstance = global.mmkvCreateNewInstance(configuration);
+    this.nativeInstance = createMMKV(configuration);
     this.functionCache = {};
   }
 

--- a/src/createMMKV.ts
+++ b/src/createMMKV.ts
@@ -1,13 +1,11 @@
-import type { MMKVConfiguration, MMKVInterface } from 'react-native-mmkv';
+import type { MMKVConfiguration, NativeMMKV } from 'react-native-mmkv';
 
 // global func declaration for JSI functions
 declare global {
-  function mmkvCreateNewInstance(
-    configuration: MMKVConfiguration
-  ): MMKVInterface;
+  function mmkvCreateNewInstance(configuration: MMKVConfiguration): NativeMMKV;
 }
 
-export const createMMKV = (config: MMKVConfiguration): MMKVInterface => {
+export const createMMKV = (config: MMKVConfiguration): NativeMMKV => {
   if (global.mmkvCreateNewInstance == null) {
     throw new Error(
       'Failed to create a new MMKV instance, the native initializer function does not exist. Is the native MMKV library correctly installed? Make sure to disable any remote debugger (e.g. Chrome) to use JSI!'

--- a/src/createMMKV.ts
+++ b/src/createMMKV.ts
@@ -1,0 +1,18 @@
+import type { MMKVConfiguration, MMKVInterface } from 'react-native-mmkv';
+
+// global func declaration for JSI functions
+declare global {
+  function mmkvCreateNewInstance(
+    configuration: MMKVConfiguration
+  ): MMKVInterface;
+}
+
+export const createMMKV = (config: MMKVConfiguration): MMKVInterface => {
+  if (global.mmkvCreateNewInstance == null) {
+    throw new Error(
+      'Failed to create a new MMKV instance, the native initializer function does not exist. Is the native MMKV library correctly installed? Make sure to disable any remote debugger (e.g. Chrome) to use JSI!'
+    );
+  }
+
+  return global.mmkvCreateNewInstance(config);
+};

--- a/src/createMMKV.web.ts
+++ b/src/createMMKV.web.ts
@@ -1,17 +1,18 @@
 import type { MMKVConfiguration, MMKVInterface } from 'react-native-mmkv';
 
-// @ts-expect-error global func is a native JSI func
 export const createMMKV = (config: MMKVConfiguration): MMKVInterface => {
-  // TODO: Implement custom ID
+  const prefix = config.id;
   // TODO: Implement Encryption
   // TODO: Implement custom Path?
   return {
     clearAll: () => localStorage.clear(),
-    delete: (key) => localStorage.removeItem(key),
-    set: (key, value) => localStorage.setItem(key, value),
-    getString: (key) => localStorage.getItem(key),
-    getNumber: (key) => Number(localStorage.getItem(key)),
-    getBoolean: (key) => Boolean(localStorage.getItem(key)),
-    getAllKeys: () => Object.keys(localStorage),
+    delete: (key) => localStorage.removeItem(`${prefix}.${key}`),
+    set: (key, value) => localStorage.setItem(`${prefix}.${key}`, value),
+    getString: (key) => localStorage.getItem(`${prefix}.${key}`) ?? undefined,
+    getNumber: (key) => Number(localStorage.getItem(`${prefix}.${key}`) ?? 0),
+    getBoolean: (key) =>
+      Boolean(localStorage.getItem(`${prefix}.${key}`) ?? false),
+    getAllKeys: () =>
+      Object.keys(localStorage).map((key) => key.replace(`${prefix}.`, '')),
   };
 };

--- a/src/createMMKV.web.ts
+++ b/src/createMMKV.web.ts
@@ -1,7 +1,12 @@
 /* global localStorage */
 import { Platform } from 'react-native';
 import type { MMKVConfiguration, MMKVInterface } from 'react-native-mmkv';
-import { canUseDOM } from 'fbjs/lib/ExecutionEnvironment';
+
+const canUseDOM = !!(
+  typeof window !== 'undefined' &&
+  window.document &&
+  window.document.createElement
+);
 
 export const createMMKV = (config: MMKVConfiguration): MMKVInterface => {
   const storage = () => {

--- a/src/createMMKV.web.ts
+++ b/src/createMMKV.web.ts
@@ -1,18 +1,26 @@
+/* global localStorage */
+import { Platform } from 'react-native';
 import type { MMKVConfiguration, MMKVInterface } from 'react-native-mmkv';
 
 export const createMMKV = (config: MMKVConfiguration): MMKVInterface => {
+  // @ts-expect-error
+  const storage = global.localStorage ?? window.localStorage ?? localStorage;
+  if (storage == null) {
+    throw new Error(
+      `Could not find 'localStorage' instance! Platform: ${Platform.OS}`
+    );
+  }
   const prefix = config.id;
   // TODO: Implement Encryption
   // TODO: Implement custom Path?
   return {
-    clearAll: () => localStorage.clear(),
-    delete: (key) => localStorage.removeItem(`${prefix}.${key}`),
-    set: (key, value) => localStorage.setItem(`${prefix}.${key}`, value),
-    getString: (key) => localStorage.getItem(`${prefix}.${key}`) ?? undefined,
-    getNumber: (key) => Number(localStorage.getItem(`${prefix}.${key}`) ?? 0),
-    getBoolean: (key) =>
-      Boolean(localStorage.getItem(`${prefix}.${key}`) ?? false),
+    clearAll: () => storage.clear(),
+    delete: (key) => storage.removeItem(`${prefix}.${key}`),
+    set: (key, value) => storage.setItem(`${prefix}.${key}`, value),
+    getString: (key) => storage.getItem(`${prefix}.${key}`) ?? undefined,
+    getNumber: (key) => Number(storage.getItem(`${prefix}.${key}`) ?? 0),
+    getBoolean: (key) => Boolean(storage.getItem(`${prefix}.${key}`) ?? false),
     getAllKeys: () =>
-      Object.keys(localStorage).map((key) => key.replace(`${prefix}.`, '')),
+      Object.keys(storage).map((key) => key.substring(prefix.length + 1)),
   };
 };

--- a/src/createMMKV.web.ts
+++ b/src/createMMKV.web.ts
@@ -1,0 +1,17 @@
+import type { MMKVConfiguration, MMKVInterface } from 'react-native-mmkv';
+
+// @ts-expect-error global func is a native JSI func
+export const createMMKV = (config: MMKVConfiguration): MMKVInterface => {
+  // TODO: Implement custom ID
+  // TODO: Implement Encryption
+  // TODO: Implement custom Path?
+  return {
+    clearAll: () => localStorage.clear(),
+    delete: (key) => localStorage.removeItem(key),
+    set: (key, value) => localStorage.setItem(key, value),
+    getString: (key) => localStorage.getItem(key),
+    getNumber: (key) => Number(localStorage.getItem(key)),
+    getBoolean: (key) => Boolean(localStorage.getItem(key)),
+    getAllKeys: () => Object.keys(localStorage),
+  };
+};

--- a/src/createMMKV.web.ts
+++ b/src/createMMKV.web.ts
@@ -1,14 +1,20 @@
 /* global localStorage */
-import { Platform } from 'react-native';
-import type { MMKVConfiguration, MMKVInterface } from 'react-native-mmkv';
+import type { MMKVConfiguration, NativeMMKV } from 'react-native-mmkv';
 
-const canUseDOM = !!(
-  typeof window !== 'undefined' &&
-  window.document &&
-  window.document.createElement
-);
+const canUseDOM =
+  typeof window !== 'undefined' && window.document?.createElement != null;
 
-export const createMMKV = (config: MMKVConfiguration): MMKVInterface => {
+export const createMMKV = (config: MMKVConfiguration): NativeMMKV => {
+  if (config.id !== 'mmkv.default') {
+    throw new Error("MMKV: 'id' is not supported on Web!");
+  }
+  if (config.encryptionKey != null) {
+    throw new Error("MMKV: 'encryptionKey' is not supported on Web!");
+  }
+  if (config.path != null) {
+    throw new Error("MMKV: 'path' is not supported on Web!");
+  }
+
   const storage = () => {
     if (!canUseDOM) {
       throw new Error(
@@ -17,24 +23,20 @@ export const createMMKV = (config: MMKVConfiguration): MMKVInterface => {
     }
     const domStorage =
       global?.localStorage ?? window?.localStorage ?? localStorage;
-    if (!domStorage) {
-      throw new Error(
-        `Could not find 'localStorage' instance! Platform: ${Platform.OS}`
-      );
+    if (domStorage == null) {
+      throw new Error(`Could not find 'localStorage' instance!`);
     }
     return domStorage;
   };
 
-  // TODO: Support custom instances?
-  // TODO: Implement Encryption
-  // TODO: Implement custom Path?
   return {
     clearAll: () => storage().clear(),
     delete: (key) => storage().removeItem(key),
-    set: (key, value) => storage().setItem(key, value),
+    set: (key, value) => storage().setItem(key, value.toString()),
     getString: (key) => storage().getItem(key) ?? undefined,
     getNumber: (key) => Number(storage().getItem(key) ?? 0),
     getBoolean: (key) => Boolean(storage().getItem(key) ?? false),
     getAllKeys: () => Object.keys(storage()),
+    contains: (key) => storage().getItem(key) != null,
   };
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "importsNotUsedAsValues": "error",
     "forceConsistentCasingInFileNames": true,
     "jsx": "react-native",
-    "lib": ["esnext"],
+    "lib": ["esnext", "DOM"],
     "module": "esnext",
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
Adds support for MMKV on the Web.

This uses the [`localStorage` API](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) instead of MMKV as a "native" instance.

On _native_ (iOS/Android) nothing changes.

Solves #11