### PR TITLE
fix: make bootstrap script work on windows

### DIFF
--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -1,3 +1,4 @@
+const os = require('os');
 const path = require('path');
 const child_process = require('child_process');
 
@@ -9,6 +10,10 @@ const options = {
   stdio: 'inherit',
   encoding: 'utf-8',
 };
+
+if (os.type() === 'Windows_NT') {
+  options.shell = true
+}
 
 let result;
 


### PR DESCRIPTION
This PR adds the same fix from https://github.com/callstack/react-native-builder-bob/commit/8bac4d4 I added over at `vision-camera-image-labeler` to make the `yarn` override script work on Windows.