### PR TITLE
Add jsi.cpp to the list of libraries used in CMakeLists.txt

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -14,6 +14,7 @@ include_directories(
 
 add_library(reactnativemmkv  # <-- Library name
         SHARED
+        "${NODE_MODULES_DIR}/react-native/ReactCommon/jsi/jsi/jsi.cpp"
         src/main/cpp/cpp-adapter.cpp
         src/main/cpp/MmkvHostObject.cpp
 )


### PR DESCRIPTION
This fixes the issue I had building an expo bare app. I also tested it with the included React Native CLI app to make sure it didn't break it. This library inspired me to learn about JSI. Thank you! 😊 