### PR TITLE
fix: typescript for JSI global functions

### DIFF
--- a/src/MMKV.ts
+++ b/src/MMKV.ts
@@ -76,7 +76,7 @@ export interface MMKVInterface {
   clearAll: () => void;
 }
 
-// global func declaration from JSI functions
+// global func declaration for JSI functions
 declare global {
   function mmkvCreateNewInstance(
     configuration: MMKVConfiguration

--- a/src/MMKV.ts
+++ b/src/MMKV.ts
@@ -76,6 +76,13 @@ export interface MMKVInterface {
   clearAll: () => void;
 }
 
+// global func declaration from JSI functions
+declare global {
+  function mmkvCreateNewInstance(
+    configuration: MMKVConfiguration
+  ): MMKVInterface;
+}
+
 /**
  * A single MMKV instance.
  */
@@ -88,13 +95,11 @@ export class MMKV implements MMKVInterface {
    * If no custom `id` is supplied, `'default'` will be used.
    */
   constructor(configuration: MMKVConfiguration = { id: 'mmkv.default' }) {
-    // @ts-expect-error global func is a native JSI func
     if (global.mmkvCreateNewInstance == null) {
       throw new Error(
         'Failed to create a new MMKV instance, the native initializer function does not exist. Is the native MMKV library correctly installed? Make sure to disable any remote debugger (e.g. Chrome) to use JSI!'
       );
     }
-    // @ts-expect-error global func is a native JSI func
     this.nativeInstance = global.mmkvCreateNewInstance(configuration);
     this.functionCache = {};
   }


### PR DESCRIPTION
## Overview
Declared global functions that come from JSI to remove type error and `@ts-expect-error`.

![image](https://user-images.githubusercontent.com/42688281/134753289-28f2da1e-ade7-468c-af6f-c14452188eac.png)
