### PR TITLE
Fix: Android rebuild command

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ if (rootProject.ext.has('reactNativeAndroidRoot')) {
 } else {
   reactNativeDir = new File(
           projectDir,
-          '/../../../node_modules/react-native/android'
+          '/../node_modules/react-native/android'
   )
 }
 if (reactNativeDir.exists()) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -128,7 +128,35 @@ dependencies {
   extractJNI(files(rnAAR))
 }
 
-task extractJNIFiles {
+task extractJNIFilesForExternal {
+  doLast {
+    configurations.extractJNI.files.each {
+      def file = it.absoluteFile
+
+      copy {
+        from zipTree(file)
+        into "$buildDir/$file.name"
+        include "jni/**/*"
+      }
+    }
+  }
+}
+
+task extractJNIFilesForDebug {
+  doLast {
+    configurations.extractJNI.files.each {
+      def file = it.absoluteFile
+
+      copy {
+        from zipTree(file)
+        into "$buildDir/$file.name"
+        include "jni/**/*"
+      }
+    }
+  }
+}
+
+task extractJNIFilesForRelease {
   doLast {
     configurations.extractJNI.files.each {
       def file = it.absoluteFile
@@ -144,6 +172,14 @@ task extractJNIFiles {
 
 tasks.whenTaskAdded { task ->
   if (task.name.contains('externalNativeBuild')) {
-    task.dependsOn(extractJNIFiles)
+    task.dependsOn(extractJNIFilesForExternal);
+  }
+
+  if (task.name.contains('generateJsonModelDebug')) {
+    task.dependsOn(extractJNIFilesForDebug);
+  }
+
+  if (task.name.contains('generateJsonModelRelease')) {
+    task.dependsOn(extractJNIFilesForRelease)
   }
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -209,7 +209,7 @@ PODS:
     - React-jsi (= 0.65.1)
     - React-perflogger (= 0.65.1)
   - React-jsinspector (0.65.1)
-  - react-native-mmkv (1.3.1):
+  - react-native-mmkv (1.3.2):
     - MMKV
     - React-Core
   - React-perflogger (0.65.1)
@@ -403,7 +403,7 @@ SPEC CHECKSUMS:
   React-jsi: 12913c841713a15f64eabf5c9ad98592c0ec5940
   React-jsiexecutor: 43f2542aed3c26e42175b339f8d37fe3dd683765
   React-jsinspector: 41e58e5b8e3e0bf061fdf725b03f2144014a8fb0
-  react-native-mmkv: 306a07a210146ab43bd50c6ade09cc2fbd386424
+  react-native-mmkv: fec24eceb3afb9bfe744e5c8f88c44d6d05afc98
   React-perflogger: fd28ee1f2b5b150b00043f0301d96bd417fdc339
   React-RCTActionSheet: 7f3fa0855c346aa5d7c60f9ced16e067db6d29fa
   React-RCTAnimation: 2119a18ee26159004b001bc56404ca5dbaae6077


### PR DESCRIPTION
The problem:
Rebuild commands like
`./gradlew clean buildDebug`
`./gradlew clean buildRelease`
`./gradlew clean assembleDebug`
`./gradlew clean assembleRelease`
and other similar commands throw the gradle exception which is described [here](https://github.com/mrousavy/react-native-mmkv/issues/145)

That is possible solution from [here](https://github.com/ammarahm-ed/react-native-simple-jsi/issues/1#issuecomment-930287524).
Checked on example project and looks like it works