### PR TITLE
fix: Use WeakRef to keep track of instances and listeners

### DIFF
--- a/src/MMKV.ts
+++ b/src/MMKV.ts
@@ -1,3 +1,4 @@
+/* global WeakRef */
 import { unstable_batchedUpdates } from 'react-native';
 
 interface Listener {


### PR DESCRIPTION
With the current solution, listeners are shared across instances with the same ID. This has the downside of causing a memory leak - listeners are held strongly even after an instance has been destroyed. I have now fixed this by using a `WeakRef` to the MMKV instance, which drops the listener when the MMKV instance has been garbage collected.