### PR TITLE
Fix bug in useMMKV

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -32,7 +32,10 @@ export function useMMKV(
   const instance = useRef<MMKV>();
 
   const lastConfiguration = useRef<MMKVConfiguration>();
-  if (lastConfiguration.current == null || !isConfigurationEqual(lastConfiguration.current, configuration)) {
+  if (
+    lastConfiguration.current == null ||
+    !isConfigurationEqual(lastConfiguration.current, configuration)
+  ) {
     lastConfiguration.current = configuration;
     instance.current = new MMKV(configuration);
   }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -32,7 +32,7 @@ export function useMMKV(
   const instance = useRef<MMKV>();
 
   const lastConfiguration = useRef<MMKVConfiguration>();
-  if (!lastConfiguration.current || !isConfigurationEqual(lastConfiguration.current, configuration)) {
+  if (lastConfiguration.current == null || !isConfigurationEqual(lastConfiguration.current, configuration)) {
     lastConfiguration.current = configuration;
     instance.current = new MMKV(configuration);
   }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -31,8 +31,9 @@ export function useMMKV(
 ): React.RefObject<MMKV> {
   const instance = useRef<MMKV>();
 
-  const lastConfiguration = useRef<MMKVConfiguration>(configuration);
-  if (!isConfigurationEqual(lastConfiguration.current, configuration)) {
+  const lastConfiguration = useRef<MMKVConfiguration>();
+  if (!lastConfiguration.current || !isConfigurationEqual(lastConfiguration.current, configuration)) {
+    lastConfiguration.current = configuration;
     instance.current = new MMKV(configuration);
   }
 


### PR DESCRIPTION
When we initially call useMMKV, `lastConfiguration` is initialized, causing `!isConfigurationEqual(lastConfiguration.current, configuration)` to be `false` and we don't save a new MMKV instance. The solution I propose should fix this issue.