### PR TITLE
fix: handle case when key is changing

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -85,7 +85,7 @@ function createMMKVHook<
       });
       return () => listener.remove();
     }, [key, mmkv]);
-    
+
     useEffect(() => {
       setValue(getter(mmkv, key));
     }, [key, mmkv]);

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -85,6 +85,10 @@ function createMMKVHook<
       });
       return () => listener.remove();
     }, [key, mmkv]);
+    
+    useEffect(() => {
+      setValue(getter(mmkv, key));
+    }, [key, mmkv]);
 
     return useMemo(() => [value, set], [value, set]);
   };


### PR DESCRIPTION
We have a given case:

```
const address = useAddress()
const [value] = useMMKVBoolean('state-' + address)
```

Currently, this is not working 