### PR TITLE
Fix extract tasks being added to clean tasks

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -347,7 +347,7 @@ task extractJNIFiles {
 extractJNIFiles.mustRunAfter extractAARHeaders
 
 tasks.whenTaskAdded { task ->
-  if (task.name.contains('externalNative') || task.name.contains('CMake')) {
+  if (!task.name.contains('Clean') && (task.name.contains('externalNative') || task.name.contains('CMake'))) {
     task.dependsOn(extractAARHeaders)
     task.dependsOn(extractJNIFiles)
     task.dependsOn(prepareThirdPartyNdkHeaders)


### PR DESCRIPTION
The extract tasks are being incorrectly added to clean tasks (`externalNativeBuild{Debug|Release}Clean`) which causes files to be missing when running `./gradlew clean assembleRelease`.