### PR TITLE
[Feat]: Add `useMMKVValueChangedListener` hook

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -60,3 +60,23 @@ function App() {
   const [username, setUsername] = useMMKVString("user.name", userStorage)
 }
 ```
+
+## Reactively use MMKV Value Changed Listener
+
+```tsx
+function App() {
+  const userStorage = useMMKV({ id: `${userId}.storage` })
+
+  useMMKVValueChangedListener((changedKey, store) => {
+    console.log(
+      `"${changedKey}" new value: ${store.getString(
+        changedKey
+      )}`
+    )
+  }, userStorage.current)
+
+  const onLogin = useCallback(() => {
+    userStorage.current.set("user.name", "Marc")
+  }, [userStorage])
+}
+```

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -67,9 +67,9 @@ function App() {
 function App() {
   const userStorage = useMMKV({ id: `${userId}.storage` })
 
-  useMMKVValueChangedListener((changedKey, store) => {
+  useMMKVValueChangedListener((changedKey) => {
     console.log(
-      `"${changedKey}" new value: ${store.getString(
+      `"${changedKey}" new value: ${userStorage.current.getString(
         changedKey
       )}`
     )

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -75,9 +75,9 @@ export default function App() {
     };
   }, [example, setExample]);
 
-  useMMKVValueChangedListener((changedKey, instance) => {
+  useMMKVValueChangedListener((changedKey) => {
     console.log(
-      `MMKV Value Changed key: ${changedKey} value: ${instance.getString(
+      `MMKV Value Changed key: ${changedKey} value: ${storage.getString(
         changedKey
       )}`
     );

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 
 import { StyleSheet, View, TextInput, Alert, Button, Text } from 'react-native';
-import { MMKV, useMMKVString } from 'react-native-mmkv';
+import {
+  MMKV,
+  useMMKVString,
+  useMMKVValueChangedListener,
+} from 'react-native-mmkv';
 
 // Uncomment to run benchmark
 // import { benchmarkAgainstAsyncStorage } from './Benchmarks';
@@ -70,6 +74,14 @@ export default function App() {
       clearInterval(interval);
     };
   }, [example, setExample]);
+
+  useMMKVValueChangedListener((changedKey, instance) => {
+    console.log(
+      `MMKV Value Changed key: ${changedKey} value: ${instance.getString(
+        changedKey
+      )}`
+    );
+  }, storage);
 
   return (
     <View style={styles.container}>

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -168,10 +168,10 @@ export function useMMKVValueChangedListener(
 ) {
   const callbackRef = useRef(callback);
   callbackRef.current = callback;
-  
+
   useEffect(() => {
     const listener = instance.addOnValueChangedListener((changedKey) => {
-      callbackRef.current(changedKey)
+      callbackRef.current(changedKey);
     });
     return () => listener.remove();
   }, [instance]);

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -161,3 +161,21 @@ export function useMMKVObject<T>(
 
   return [value, setValue];
 }
+
+export function useMMKVValueChangedListener(
+  callback: (changedKey: string, storage: MMKV) => void,
+  instance: MMKV | null
+) {
+  useEffect(() => {
+    if (!instance) return;
+
+    const listener = instance.addOnValueChangedListener((changedKey) =>
+      callback(changedKey, instance)
+    );
+    // cleanup function
+    return () => {
+      listener.remove();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [instance]);
+}

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -163,19 +163,16 @@ export function useMMKVObject<T>(
 }
 
 export function useMMKVValueChangedListener(
-  callback: (changedKey: string, storage: MMKV) => void,
-  instance: MMKV | null
+  callback: (changedKey: string) => void,
+  instance: MMKV
 ) {
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+  
   useEffect(() => {
-    if (!instance) return;
-
-    const listener = instance.addOnValueChangedListener((changedKey) =>
-      callback(changedKey, instance)
-    );
-    // cleanup function
-    return () => {
-      listener.remove();
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const listener = instance.addOnValueChangedListener((changedKey) => {
+      callbackRef.current(changedKey)
+    });
+    return () => listener.remove();
   }, [instance]);
 }


### PR DESCRIPTION
This hook was introduced to simplify the usage of [`addOnValueChangedListener `](https://github.com/mrousavy/react-native-mmkv/blob/master/docs/LISTENERS.md).
## Instead of
```tsx
useEffect(() => {
  const listener = storage.addOnValueChangedListener((changedKey) => {
    const newValue = storage.getString(changedKey)
    console.log(`"${changedKey}" new value: ${newValue}`)
  })
  // cleanup function
  return () => {
    listener.remove()
  }
}, [storage])
```
## Then
```tsx
useMMKVValueChangedListener((changedKey) => {
    console.log(
      `"${changedKey}" new value: ${storage.getString(
        changedKey
      )}`
    );
  }, storage);
```

### **If this feature is a good idea, you may provide suggestions/corrections and i will be available to make amendments**

## Todos
- [x] create `useMMKVValueChangedListener` hook 7b0911f7447b3db56b4230dd79516a5a4a0a2efe
- [x] add `useMMKVValueChangedListener` example a9bf26516b25177a1b80b9d79bbaa618c5c3e834
- [x] add `useMMKVValueChangedListener` to hook read me 34edc55
- [x] add Description to this PR