### PR TITLE
feat: Use `undefined` as a default value (**BREAKING CHANGE**)

### DIFF
--- a/android/src/main/cpp/MmkvHostObject.cpp
+++ b/android/src/main/cpp/MmkvHostObject.cpp
@@ -63,8 +63,8 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
       if (!arguments[0].isString()) {
         throw jsi::JSError(runtime, "MMKV::set: First argument ('key') has to be of type string!");
       }
-      auto keyName = arguments[0].getString(runtime).utf8(runtime);
 
+      auto keyName = arguments[0].getString(runtime).utf8(runtime);
       if (arguments[1].isBool()) {
         instance->set(arguments[1].getBool(), keyName);
       } else if (arguments[1].isNumber()) {
@@ -93,10 +93,8 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
       }
 
       auto keyName = arguments[0].getString(runtime).utf8(runtime);
-
       bool hasValue;
       auto value = instance->getBool(keyName, false, &hasValue);
-
       if (hasValue) {
         return jsi::Value(value);
       } else {
@@ -119,10 +117,8 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
       }
 
       auto keyName = arguments[0].getString(runtime).utf8(runtime);
-
       std::string result;
       bool hasValue = instance->getString(keyName, result);
-
       if (hasValue) {
         return jsi::Value(runtime, jsi::String::createFromUtf8(runtime, result));
       } else {
@@ -143,11 +139,10 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
       if (!arguments[0].isString()) {
         throw jsi::JSError(runtime, "First argument ('key') has to be of type string!");
       }
-      auto keyName = arguments[0].getString(runtime).utf8(runtime);
 
+      auto keyName = arguments[0].getString(runtime).utf8(runtime);
       bool hasValue;
       auto value = instance->getDouble(keyName, 0.0, &hasValue);
-
       if (hasValue) {
         return jsi::Value(value);
       } else {
@@ -168,8 +163,8 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
       if (!arguments[0].isString()) {
         throw jsi::JSError(runtime, "First argument ('key') has to be of type string!");
       }
-      auto keyName = arguments[0].getString(runtime).utf8(runtime);
 
+      auto keyName = arguments[0].getString(runtime).utf8(runtime);
       bool containsKey = instance->containsKey(keyName);
       return jsi::Value(containsKey);
     });
@@ -187,8 +182,8 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
       if (!arguments[0].isString()) {
         throw jsi::JSError(runtime, "First argument ('key') has to be of type string!");
       }
-      auto keyName = arguments[0].getString(runtime).utf8(runtime);
 
+      auto keyName = arguments[0].getString(runtime).utf8(runtime);
       instance->removeValueForKey(keyName);
       return jsi::Value::undefined();
     });

--- a/android/src/main/cpp/MmkvHostObject.cpp
+++ b/android/src/main/cpp/MmkvHostObject.cpp
@@ -93,17 +93,15 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
       }
 
       auto keyName = arguments[0].getString(runtime).utf8(runtime);
-      auto value = instance->getBool(keyName);
 
-      if (value == false) {
-        // If the value is `false` (default value), we check if the key even exists.
-        if (!instance->containsKey(keyName)) {
-          // The key doesn't even exist, so let's return `undefined` instead of `false`.
-          return jsi::Value::undefined();
-        }
+      bool hasValue;
+      auto value = instance->getBool(keyName, false, &hasValue);
+
+      if (hasValue) {
+        return jsi::Value(value);
+      } else {
+        return jsi::Value::undefined();
       }
-
-      return jsi::Value(value);
     });
   }
 
@@ -124,6 +122,7 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
 
       std::string result;
       bool hasValue = instance->getString(keyName, result);
+
       if (hasValue) {
         return jsi::Value(runtime, jsi::String::createFromUtf8(runtime, result));
       } else {
@@ -146,17 +145,14 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
       }
       auto keyName = arguments[0].getString(runtime).utf8(runtime);
 
-      auto value = instance->getDouble(keyName);
+      bool hasValue;
+      auto value = instance->getDouble(keyName, 0.0, &hasValue);
 
-      if (value == 0.0) {
-        // If the value is `0.0` (default value), we check if the key even exists.
-        if (!instance->containsKey(keyName)) {
-          // The key doesn't even exist, so let's return `undefined` instead of `0.0`.
-          return jsi::Value::undefined();
-        }
+      if (hasValue) {
+        return jsi::Value(value);
+      } else {
+        return jsi::Value::undefined();
       }
-
-      return jsi::Value(value);
     });
   }
 

--- a/android/src/main/cpp/MmkvHostObject.cpp
+++ b/android/src/main/cpp/MmkvHostObject.cpp
@@ -9,6 +9,7 @@
 #include "MmkvHostObject.h"
 #include <MMKV.h>
 #include <android/log.h>
+#include <string>
 
 MmkvHostObject::MmkvHostObject(const std::string& instanceId, std::string path, std::string cryptKey) {
   __android_log_print(ANDROID_LOG_INFO, "RNMMKV", "Creating MMKV instance \"%s\"... (Path: %s, Encryption-Key: %s)",

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -11,9 +11,9 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.66.0)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - MMKV (1.2.10):
-    - MMKVCore (~> 1.2.10)
-  - MMKVCore (1.2.10)
+  - MMKV (1.2.13):
+    - MMKVCore (~> 1.2.13)
+  - MMKVCore (1.2.13)
   - RCT-Folly (2021.06.28.00-v2):
     - boost
     - DoubleConversion
@@ -213,7 +213,7 @@ PODS:
   - React-logger (0.66.0):
     - glog
   - react-native-mmkv (2.2.0):
-    - MMKV
+    - MMKV (>= 1.2.13)
     - React-Core
   - React-perflogger (0.66.0)
   - React-RCTActionSheet (0.66.0):
@@ -399,8 +399,8 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 3b1e86618e902743fde35b40cf9ebd100fd655b7
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 5337263514dd6f09803962437687240c5dc39aa4
-  MMKV: 76033b9ace2006623308910a3afcc0e25eba3140
-  MMKVCore: b00e7a09ec77a1b916aef336eedd3b99ec249978
+  MMKV: aac95d817a100479445633f2b3ed8961b4ac5043
+  MMKVCore: 3388952ded307e41b3ed8a05892736a236ed1b8e
   RCT-Folly: a21c126816d8025b547704b777a2ba552f3d9fa9
   RCTRequired: e4a18a90004e0ed97bba9081099104fd0f658dc9
   RCTTypeSafety: 8a3c31d38de58e1a6a7df6e4e643644a60b00e22
@@ -413,7 +413,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 6a05173dc0142abc582bd4edd2d23146b8cc218a
   React-jsinspector: be95ad424ba9f7b817aff22732eb9b1b810a000a
   React-logger: 9a9cd87d4ea681ae929b32ef580638ff1b50fb24
-  react-native-mmkv: 2a15aadabf649c364cab7975eef52848611eea25
+  react-native-mmkv: b3fbff006ba573aa9244174166bbf18d8dc210a7
   React-perflogger: 1f554c2b684e2f484f9edcdfdaeedab039fbaca8
   React-RCTActionSheet: 610d5a5d71ab4808734782c8bca6a12ec3563672
   React-RCTAnimation: ec6ed97370ace32724c253f29f0586cafcab8126
@@ -431,4 +431,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: ff9edaeddbabd71ed0391ba2617d0998f8c3e9ba
 
-COCOAPODS: 1.10.2
+COCOAPODS: 1.11.2

--- a/ios/MmkvHostObject.mm
+++ b/ios/MmkvHostObject.mm
@@ -101,15 +101,15 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
       }
 
       auto keyName = convertJSIStringToNSString(runtime, arguments[0].getString(runtime));
-      auto value = [instance getBoolForKey:keyName];
-      if (value == false) {
-        // If the value is false (default value), we check if it even exists.
-        if (![instance containsKey:keyName]) {
-          // The key does not exist in storage, so let's return undefined
-          return jsi::Value::undefined();
-        }
+
+      bool hasValue;
+      auto value = [instance getBoolForKey:keyName defaultValue:false hasValue:&hasValue];
+
+      if (hasValue) {
+        return jsi::Value(value);
+      } else {
+        return jsi::Value::undefined();
       }
-      return jsi::Value(value);
     });
   }
 
@@ -127,7 +127,9 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
       }
 
       auto keyName = convertJSIStringToNSString(runtime, arguments[0].getString(runtime));
+
       auto value = [instance getStringForKey:keyName];
+
       if (value != nil) {
         return convertNSStringToJSIString(runtime, value);
       } else {
@@ -150,15 +152,15 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
       }
 
       auto keyName = convertJSIStringToNSString(runtime, arguments[0].getString(runtime));
-      auto value = [instance getDoubleForKey:keyName];
-      if (value == 0.0) {
-        // If the value is 0.0 (default value), we check if it even exists.
-        if (![instance containsKey:keyName]) {
-          // The key does not exist in storage, so let's return undefined
-          return jsi::Value::undefined();
-        }
+
+      bool hasValue;
+      auto value = [instance getDoubleForKey:keyName defaultValue:0.0 hasValue:&hasValue];
+
+      if (hasValue) {
+        return jsi::Value(value);
+      } else {
+        return jsi::Value::undefined();
       }
-      return jsi::Value(value);
     });
   }
 

--- a/ios/MmkvHostObject.mm
+++ b/ios/MmkvHostObject.mm
@@ -69,7 +69,7 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
       if (!arguments[0].isString()) {
         throw jsi::JSError(runtime, "First argument ('key') has to be of type string!");
       }
-      
+
       auto keyName = convertJSIStringToNSString(runtime, arguments[0].getString(runtime));
 
       if (arguments[1].isBool()) {
@@ -82,7 +82,7 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
       } else {
         throw jsi::JSError(runtime, "Second argument ('value') has to be of type bool, number or string!");
       }
-      
+
       return jsi::Value::undefined();
     });
   }
@@ -101,7 +101,14 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
       }
 
       auto keyName = convertJSIStringToNSString(runtime, arguments[0].getString(runtime));
-      bool value = [instance getBoolForKey:keyName];
+      auto value = [instance getBoolForKey:keyName];
+      if (value == false) {
+        // If the value is false (default value), we check if it even exists.
+        if (![instance containsKey:keyName]) {
+          // The key does not exist in storage, so let's return undefined
+          return jsi::Value::undefined();
+        }
+      }
       return jsi::Value(value);
     });
   }
@@ -121,10 +128,11 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
 
       auto keyName = convertJSIStringToNSString(runtime, arguments[0].getString(runtime));
       auto value = [instance getStringForKey:keyName];
-      if (value != nil)
+      if (value != nil) {
         return convertNSStringToJSIString(runtime, value);
-      else
+      } else {
         return jsi::Value::undefined();
+      }
     });
   }
 
@@ -143,6 +151,13 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
 
       auto keyName = convertJSIStringToNSString(runtime, arguments[0].getString(runtime));
       auto value = [instance getDoubleForKey:keyName];
+      if (value == 0.0) {
+        // If the value is 0.0 (default value), we check if it even exists.
+        if (![instance containsKey:keyName]) {
+          // The key does not exist in storage, so let's return undefined
+          return jsi::Value::undefined();
+        }
+      }
       return jsi::Value(value);
     });
   }

--- a/ios/MmkvHostObject.mm
+++ b/ios/MmkvHostObject.mm
@@ -67,11 +67,10 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
                                                         const jsi::Value* arguments,
                                                         size_t count) -> jsi::Value {
       if (!arguments[0].isString()) {
-        throw jsi::JSError(runtime, "First argument ('key') has to be of type string!");
+        throw jsi::JSError(runtime, "MMKV::set: First argument ('key') has to be of type string!");
       }
 
       auto keyName = convertJSIStringToNSString(runtime, arguments[0].getString(runtime));
-
       if (arguments[1].isBool()) {
         [instance setBool:arguments[1].getBool() forKey:keyName];
       } else if (arguments[1].isNumber()) {
@@ -101,10 +100,8 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
       }
 
       auto keyName = convertJSIStringToNSString(runtime, arguments[0].getString(runtime));
-
       bool hasValue;
       auto value = [instance getBoolForKey:keyName defaultValue:false hasValue:&hasValue];
-
       if (hasValue) {
         return jsi::Value(value);
       } else {
@@ -127,9 +124,7 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
       }
 
       auto keyName = convertJSIStringToNSString(runtime, arguments[0].getString(runtime));
-
       auto value = [instance getStringForKey:keyName];
-
       if (value != nil) {
         return convertNSStringToJSIString(runtime, value);
       } else {
@@ -152,10 +147,8 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
       }
 
       auto keyName = convertJSIStringToNSString(runtime, arguments[0].getString(runtime));
-
       bool hasValue;
       auto value = [instance getDoubleForKey:keyName defaultValue:0.0 hasValue:&hasValue];
-
       if (hasValue) {
         return jsi::Value(value);
       } else {

--- a/react-native-mmkv.podspec
+++ b/react-native-mmkv.podspec
@@ -26,6 +26,6 @@ Pod::Spec.new do |s|
     'ios/**/*.h'
   ]
 
-  s.dependency "MMKV"
+  s.dependency "MMKV", ">= 1.2.13"
   s.dependency "React-Core"
 end

--- a/src/MMKV.ts
+++ b/src/MMKV.ts
@@ -52,23 +52,23 @@ interface MMKVInterface {
    */
   set: (key: string, value: boolean | string | number) => void;
   /**
-   * Get a boolean value for the given `key`.
+   * Get the boolean value for the given `key`, or `undefined` if it does not exist.
    *
-   * @default false
+   * @default undefined
    */
-  getBoolean: (key: string) => boolean;
+  getBoolean: (key: string) => boolean | undefined;
   /**
-   * Get a string value for the given `key`.
+   * Get the string value for the given `key`, or `undefined` if it does not exist.
    *
    * @default undefined
    */
   getString: (key: string) => string | undefined;
   /**
-   * Get a number value for the given `key`.
+   * Get the number value for the given `key`, or `undefined` if it does not exist.
    *
-   * @default 0
+   * @default undefined
    */
-  getNumber: (key: string) => number;
+  getNumber: (key: string) => number | undefined;
   /**
    * Checks whether the given `key` is being stored in this MMKV instance.
    */
@@ -175,7 +175,7 @@ export class MMKV implements MMKVInterface {
     const func = this.getFunctionFromCache('set');
     return func(key, value);
   }
-  getBoolean(key: string): boolean {
+  getBoolean(key: string): boolean | undefined {
     const func = this.getFunctionFromCache('getBoolean');
     return func(key);
   }
@@ -183,7 +183,7 @@ export class MMKV implements MMKVInterface {
     const func = this.getFunctionFromCache('getString');
     return func(key);
   }
-  getNumber(key: string): number {
+  getNumber(key: string): number | undefined {
     const func = this.getFunctionFromCache('getNumber');
     return func(key);
   }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -50,7 +50,7 @@ export function useMMKV(configuration?: MMKVConfiguration): MMKV {
 }
 
 function createMMKVHook<
-  T extends boolean | number | (string | undefined),
+  T extends (boolean | number | string) | undefined,
   TSet extends T | undefined,
   TSetAction extends TSet | ((current: T) => TSet)
 >(getter: (instance: MMKV, key: string) => T) {


### PR DESCRIPTION
## What

This PR uses the new API I have created in my PR (https://github.com/Tencent/MMKV/pull/828) to return `undefined` instead of `0.0` (`getNumber(..)`) or `false` (`getBoolean(..)`) virtually without any added runtime cost.

## Why

Default values of `0.0` or `false` might be misleading in some cases.

## Changes

* `getNumber` now returns `undefined` instead of `0.0` if it was not found in the storage
* `getBoolean` now returns `undefined` instead of `false` if it was not found in the storage