### PR TITLE
feat: `toString()` and `toJSON()`

### DIFF
--- a/src/MMKV.ts
+++ b/src/MMKV.ts
@@ -209,6 +209,11 @@ export class MMKV implements MMKVInterface {
   toString(): string {
     return `MMKV (${this.id}): [${this.getAllKeys().join(', ')}]`;
   }
+  toJSON(): object {
+    return {
+      [this.id]: this.getAllKeys(),
+    };
+  }
 
   addOnValueChangedListener(onValueChanged: (key: string) => void): Listener {
     this.onValueChangedListeners.push(onValueChanged);

--- a/src/MMKV.ts
+++ b/src/MMKV.ts
@@ -206,6 +206,10 @@ export class MMKV implements MMKVInterface {
     return func(key);
   }
 
+  toString(): string {
+    return `MMKV (${this.id}): [${this.getAllKeys().join(', ')}]`;
+  }
+
   addOnValueChangedListener(onValueChanged: (key: string) => void): Listener {
     this.onValueChangedListeners.push(onValueChanged);
 


### PR DESCRIPTION
Implements `toString()` and `toJSON()` for MMKV instances so you can log them.

Example:

```ts
const storage = new MMKV();
console.log(storage.toString());  // <-- toString
console.log(storage);             // <-- toJSON
```

```sh
MMKV (mmkv.default): [5555, xyyyyy, test]     # <-- toString
{"mmkv.default": ["5555", "xyyyyy", "test"]}  # <-- toJSON
```