### PR TITLE
fix: normalize `INCLUDE_JSI_CPP` path in cmake

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -13,9 +13,10 @@ include_directories(
 )
 
 if(${REACT_NATIVE_VERSION} LESS 66)
-        set (
-                INCLUDE_JSI_CPP
+        file(
+                TO_CMAKE_PATH 
                 "${NODE_MODULES_DIR}/react-native/ReactCommon/jsi/jsi/jsi.cpp"
+                INCLUDE_JSI_CPP
         )
 endif()
 


### PR DESCRIPTION
This PR fixes a niche problem with CMake when trying to build version `>= 2.0.0` of this library with React Native `< 0.66.0` on Windows.

Because Windows uses backslashes in paths and `add_library()` interprets these verbatim as escape characters CMake would run into the following error:
```
CMake Error at C:\Users\yfunk\...\my-app\node_modules\react-native-mmkv\android\CMakeLists.txt:22 (add_library):
    Syntax error in cmake code when parsing string

      C:\Users\yfunk\...\my-app\node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp

    Invalid character escape '\U'.
```

I fixed this by using [`file(TO_CMAKE_PATH ...)`](https://cmake.org/cmake/help/latest/command/file.html#to-cmake-path) to set the `INCLUDE_JSI_CPP` variable, since it normalizes all backslashes into forward ones.