### PR TITLE
Convert zustand persist middleware example to Synchronous storage

### DIFF
--- a/docs/WRAPPER_ZUSTAND_PERSIST_MIDDLEWARE.md
+++ b/docs/WRAPPER_ZUSTAND_PERSIST_MIDDLEWARE.md
@@ -11,20 +11,14 @@ const storage = new MMKV()
 
 const zustandStorage: StateStorage = {
   setItem: (name, value) => {
-    storage.set(name, value)
-    return Promise.resolve()
+    return storage.set(name, value)
   },
   getItem: (name) => {
     const value = storage.getString(name)
-    if (value) {
-      return Promise.resolve(value)
-    } else {
-      return null
-    }
+    return value || null
   },
   removeItem: (name) => {
-    storage.delete(name)
-    return Promise.resolve()
+    return storage.delete(name)
   },
 }
 ```

--- a/docs/WRAPPER_ZUSTAND_PERSIST_MIDDLEWARE.md
+++ b/docs/WRAPPER_ZUSTAND_PERSIST_MIDDLEWARE.md
@@ -15,7 +15,7 @@ const zustandStorage: StateStorage = {
   },
   getItem: (name) => {
     const value = storage.getString(name)
-    return value || null
+    return value ?? null
   },
   removeItem: (name) => {
     return storage.delete(name)


### PR DESCRIPTION
Zustand persist middleware accepts synchronous storage methods too, so there is no need for a Promise based definition.
[Zustand Persist Docs](https://github.com/pmndrs/zustand/blob/main/src/middleware/persist.ts#L7)