### PR TITLE
Fix: Main thread error with initialize function

### DIFF
--- a/ios/MmkvModule.mm
+++ b/ios/MmkvModule.mm
@@ -37,8 +37,10 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install:(nullable NSString*)storageDirect
     }
     auto& runtime = *jsiRuntime;
 
+    dispatch_async(dispatch_get_main_queue(), ^{
     [MMKV initializeMMKV:storageDirectory];
-
+    });
+  
     // MMKV.createNewInstance()
     auto mmkvCreateNewInstance = jsi::Function::createFromHostFunction(runtime,
                                                                         jsi::PropNameID::forAscii(runtime, "mmkvCreateNewInstance"),


### PR DESCRIPTION
It is mentioned in main MMKV package that  [MMKV initializeMMKV:nil] function should always initialize in a main thread.
Reference: https://github.com/Tencent/MMKV#quick-tutorial-1