### PR TITLE
chore: clarify the `id` field docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This creates a new storage instance using a custom MMKV storage ID. By using a c
 
 The following values can be configured:
 
-* `id`: The MMKV instance's ID. If you want to use multiple instances, use different IDs. For example, you can separte the global app's storage and a logged-in user's storage. (default: `'mmkv.default'`)
+* `id`: The MMKV instance's ID. If you want to use multiple instances, use different IDs. For example, you can separte the global app's storage and a logged-in user's storage. (required if `path` or `encryptionKey` fields are specified, otherwise defaults to: `'mmkv.default'`)
 * `path`: The MMKV instance's root path. By default, MMKV stores file inside `$(Documents)/mmkv/`. You can customize MMKV's root directory on MMKV initialization (documentation: [iOS](https://github.com/Tencent/MMKV/wiki/iOS_advance#customize-location) / [Android](https://github.com/Tencent/MMKV/wiki/android_advance#customize-location))
 * `encryptionKey`: The MMKV instance's encryption/decryption key. By default, MMKV stores all key-values in plain text on file, relying on iOS's/Android's sandbox to make sure the file is encrypted. Should you worry about information leaking, you can choose to encrypt MMKV. (documentation: [iOS](https://github.com/Tencent/MMKV/wiki/iOS_advance#encryption) / [Android](https://github.com/Tencent/MMKV/wiki/android_advance#encryption))
 


### PR DESCRIPTION
# Why

Refs:
* https://github.com/mrousavy/react-native-mmkv/issues/347#issuecomment-1063958167

# How

This PR adds a clarification to the `id` config field description and default fallback behavior, which has been explained by Marc in the referenced issue. 