### PR TITLE
fix getBoolean on the Web

### DIFF
--- a/src/createMMKV.web.ts
+++ b/src/createMMKV.web.ts
@@ -42,7 +42,15 @@ export const createMMKV = (config: MMKVConfiguration): NativeMMKV => {
     getBoolean: (key) => {
       const value = storage().getItem(key);
       if (value == null) return undefined;
-      return Boolean(value);
+      /**
+       * local storage saves keys and values in utf-16 dom strings
+       * @link https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage#description
+       * true is saved as 'true', false as 'false'
+       * so if value == 'true' return true
+       * if value == 'false' return false
+       * I just simplified the conditions
+       */
+      return value === 'true';
     },
     getAllKeys: () => Object.keys(storage()),
     contains: (key) => storage().getItem(key) != null,

--- a/src/createMMKV.web.ts
+++ b/src/createMMKV.web.ts
@@ -42,14 +42,6 @@ export const createMMKV = (config: MMKVConfiguration): NativeMMKV => {
     getBoolean: (key) => {
       const value = storage().getItem(key);
       if (value == null) return undefined;
-      /**
-       * local storage saves keys and values in utf-16 dom strings
-       * @link https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage#description
-       * true is saved as 'true', false as 'false'
-       * so if value == 'true' return true
-       * if value == 'false' return false
-       * I just simplified the conditions
-       */
       return value === 'true';
     },
     getAllKeys: () => Object.keys(storage()),


### PR DESCRIPTION
local storage saves values in string format. so  Boolean('false') is always true. for this method to work correctly, it should check if value is 'true' or 'false' as string and returns the condition result.
to simplify the code I just return value === 'true'  
