### PR TITLE
Force cmake >3.9.0 to fix build issues

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -113,6 +113,7 @@ android {
 
   externalNativeBuild {
     cmake {
+      version "3.9.0+"
       path "CMakeLists.txt"
     }
   }


### PR DESCRIPTION
This project requires at least cmake version 3.9.0 to compile properly, while Android Studio's sdk manager defaults to cmake 3.6.0.

Despite updating cmake both through Android Studio and manually, and configuring my project to use the new versions, the build process was still using 3.6.0. Setting the cmake version and ndk version in my app's build,gradle android along with cmake.dir in gradle.properties did not help.

I believe this is the same issue as #299 

This simple change fixed it on my end, without requiring the library user to hack around with configurations until it works.