### PR TITLE
fix: Fix build.gradle for RN 0.69

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -205,7 +205,7 @@ task createNativeDepsDirectories {
 }
 
 task downloadBoost(dependsOn: createNativeDepsDirectories, type: Download) {
-  src("https://github.com/react-native-community/boost-for-react-native/releases/download/v${BOOST_VERSION.replace("_", ".")}-0/boost_${BOOST_VERSION}.tar.gz")
+  src("https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION.replace("_", ".")}/source/boost_${BOOST_VERSION}.tar.gz")
   onlyIfNewer(true)
   overwrite(false)
   dest(boost_file)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -203,7 +203,12 @@ task createNativeDepsDirectories {
 }
 
 task downloadBoost(dependsOn: createNativeDepsDirectories, type: Download) {
-  src("https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION.replace("_", ".")}/source/boost_${BOOST_VERSION}.tar.gz")
+  def transformedVersion = BOOST_VERSION.replace("_", ".")
+  def srcUrl = "https://boostorg.jfrog.io/artifactory/main/release/${transformedVersion}/source/boost_${BOOST_VERSION}.tar.gz"
+  if (REACT_NATIVE_VERSION < 69) {
+    srcUrl = "https://github.com/react-native-community/boost-for-react-native/releases/download/v${transformedVersion}-0/boost_${BOOST_VERSION}.tar.gz"
+  }
+  src(srcUrl)
   onlyIfNewer(true)
   overwrite(false)
   dest(boost_file)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -160,7 +160,19 @@ dependencies {
   extractJNI("com.facebook.fbjni:fbjni:+")
 
   if (!sourceBuild) {
-    def rnAAR = fileTree("${defaultDir.toString()}").matching({ it.include "**/**/*.aar" }).singleFile
+    def buildType = "debug"
+    tasks.all({ task ->
+        if (task.name == "buildCMakeRelease") {
+            buildType = "release"
+        }
+    })
+    def rnAarMatcher = "**/react-native/**/*${buildType}.aar"
+    def (major, minor, patch) = reactProperties.getProperty("VERSION_NAME").tokenize('.')
+    def rnMinorVersion = Integer.parseInt(minor)
+    if (rnMinorVersion < 69) {
+        rnAarMatcher = "**/**/*.aar"
+    }
+    def rnAAR = fileTree("${defaultDir.toString()}").matching({ it.include rnAarMatcher }).singleFile
     extractJNI(files(rnAAR))
   }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -162,13 +162,13 @@ dependencies {
   if (!sourceBuild) {
     def buildType = "debug"
     tasks.all({ task ->
-        if (task.name == "buildCMakeRelease") {
-            buildType = "release"
-        }
+      if (task.name == "buildCMakeRelease") {
+        buildType = "release"
+      }
     })
     def rnAarMatcher = "**/react-native/**/*${buildType}.aar"
     if (REACT_NATIVE_VERSION < 69) {
-        rnAarMatcher = "**/**/*.aar"
+      rnAarMatcher = "**/**/*.aar"
     }
     def rnAAR = fileTree("${defaultDir.toString()}").matching({ it.include rnAarMatcher }).singleFile
     extractJNI(files(rnAAR))

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -167,9 +167,7 @@ dependencies {
         }
     })
     def rnAarMatcher = "**/react-native/**/*${buildType}.aar"
-    def (major, minor, patch) = reactProperties.getProperty("VERSION_NAME").tokenize('.')
-    def rnMinorVersion = Integer.parseInt(minor)
-    if (rnMinorVersion < 69) {
+    if (REACT_NATIVE_VERSION < 69) {
         rnAarMatcher = "**/**/*.aar"
     }
     def rnAAR = fileTree("${defaultDir.toString()}").matching({ it.include rnAarMatcher }).singleFile


### PR DESCRIPTION
- React Native's Android source file directory pattern changed from version 0.69.0
- download boost from Jfrog directly (`boost-for-react-native` didn't update required version(v1.76.0))
(fyi. https://github.com/react-native-community/boost-for-react-native)

I think it may break example (I didn't test example)