### PR TITLE
feat: make hook reactive when instance change

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -84,12 +84,25 @@ function createMMKVHook<
 
     // update value if key changes
     const keyRef = useRef(key);
+
     useEffect(() => {
       if (key !== keyRef.current) {
         setValue(getter(mmkv, key));
         keyRef.current = key;
       }
     }, [key, mmkv]);
+
+    // update value if instance changes
+    // Note: the ref should be the instance ID 
+    const instanceRef = useRef(JSON.stringify(mmkv));
+
+    useEffect(() => {
+      // Note: we should compare instance id for better performance
+      if (instanceRef.current !== JSON.stringify(mmkv)) {
+        setValue(getter(mmkv, key));
+        instanceRef.current = JSON.stringify(mmkv);
+      }
+    }, [mmkv]);
 
     // update value if it changes somewhere else (second hook, same key)
     useEffect(() => {


### PR DESCRIPTION
Hello,

The code is not production ready, but the idea is here, for better performance we should use the **instance id** in order to compare correctly the instance.

The id field is private actually so i don't know if we would like to expose it ? 