### PR TITLE
fix: Update hook value if key **or instance** changes

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -82,13 +82,9 @@ function createMMKVHook<
       [key, mmkv]
     );
 
-    // update value if key changes
-    const keyRef = useRef(key);
+    // update value if key or instance changes
     useEffect(() => {
-      if (key !== keyRef.current) {
-        setValue(getter(mmkv, key));
-        keyRef.current = key;
-      }
+      setValue(getter(mmkv, key));
     }, [key, mmkv]);
 
     // update value if it changes somewhere else (second hook, same key)


### PR DESCRIPTION
In some rare cases, when the user passes in the same key but a different MMKV instance the hook does not update it's value:

```ts
const useMmkvList = () => {
  const defaultStorage = useMMKV()
  const demoStorage = useMMKV({ id: "demo" })
  const [env, _] = useMMKVObject("env")

  useMMKVObject("list", env.isDemoMode ? demoStorage : defaultStorage)
}
```

This PR fixes this so that the value is updated when either the key is changed, or the instance is different.

* Fixes https://github.com/mrousavy/react-native-mmkv/issues/411
* Overrides #419