### PR TITLE
Fix Android build for RN<68 when building from source - missing Gradle tasks

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -357,8 +357,12 @@ def nativeBuildDependsOn(dependsOnTask, variant) {
 
 afterEvaluate {
   if (sourceBuild) {
-    nativeBuildDependsOn(":ReactAndroid:packageReactNdkDebugLibsForBuck", "Debug")
-    nativeBuildDependsOn(":ReactAndroid:packageReactNdkReleaseLibsForBuck", "Rel")
+    if (REACT_NATIVE_VERSION < 68) {
+      nativeBuildDependsOn(":ReactAndroid:packageReactNdkLibsForBuck", null)
+    } else {
+      nativeBuildDependsOn(":ReactAndroid:packageReactNdkDebugLibsForBuck", "Debug")
+      nativeBuildDependsOn(":ReactAndroid:packageReactNdkReleaseLibsForBuck", "Rel")
+    }
   } else {
     nativeBuildDependsOn(extractAARHeaders, null)
     nativeBuildDependsOn(extractJNIFiles, null)


### PR DESCRIPTION
## Issue
When compiling with ReactNative<68 and building RN from source, the Android build fails:

```
Could not determine the dependencies of task ':react-native-mmkv:externalNativeBuildDebug'.
> Task with path ':ReactAndroid:packageReactNdkDebugLibsForBuck' not found in project ':react-native-mmkv'.
```

React Native only added these tasks in version 0.68: https://github.com/facebook/react-native/commit/d70555ff0e1967aa09b0f291c8ed1c5918f7a8a0

## Solution
For RN<68, instead of depending on separate tasks for Debug and Release (`:ReactAndroid:packageReactNdkDebugLibsForBuck` and `:ReactAndroid:packageReactNdkReleaseLibsForBuck`) we should use the old standalone task (`:ReactAndroid:packageReactNdkLibsForBuck`).