### PR TITLE
fix: use correct function call in jotai wrapper example

### DIFF
--- a/docs/WRAPPER_JOTAI.md
+++ b/docs/WRAPPER_JOTAI.md
@@ -26,7 +26,7 @@ function clearAll(): void {
 }
 
 export const atomWithMMKV = <T>(key: string, initialValue: T) =>
-  jotaiAtomWithStorage<T>(
+  atomWithStorage<T>(
     key,
     initialValue,
     createJSONStorage<T>(() => ({


### PR DESCRIPTION
Hey @mrousavy , thanks for the awesome library!

I just have a small change, which corrects the jotai wrapper example to use the correct function call in respect to the imports from `jotai/utils` 

Thanks!