### PR TITLE
Example fixes

### DIFF
--- a/docs/WRAPPER_MOBX.md
+++ b/docs/WRAPPER_MOBX.md
@@ -11,7 +11,7 @@ const storage = new MMKV()
 configurePersistable({
   storage: {
     setItem: (key, data) => storage.set(key, data),
-    getItem: (key) => storage.getString(key),
+    getItem: (key) => storage.getString(key) || null,
     removeItem: (key) => storage.delete(key),
   },
 })


### PR DESCRIPTION
"Type 'string | undefined' is not assignable to type 'string | T | Promise<string | T | null> | null'."