### PR TITLE
Allowed setting custom downloads directory

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -179,8 +179,8 @@ dependencies {
 // mostly a copy of https://github.com/software-mansion/react-native-reanimated/blob/master/android/build.gradle#L115
 
 
-
-def downloadsDir = new File("$buildDir/downloads")
+def customDownloadsDir = System.getenv("REACT_NATIVE_DOWNLOADS_DIR")
+def downloadsDir = customDownloadsDir ? new File(customDownloadsDir) : new File("$buildDir/downloads")
 def thirdPartyNdkDir = new File("$buildDir/third-party-ndk")
 def thirdPartyVersionsFile = new File("${androidSourcesDir.toString()}/ReactAndroid/gradle.properties")
 def thirdPartyVersions = new Properties()


### PR DESCRIPTION
Added support for custom download directory using `REACT_NATIVE_DOWNLOADS_DIR` environment variable. This is copied from [this PR](https://github.com/software-mansion/react-native-reanimated/pull/3552)

Fixes #436 and #455