### PR TITLE
feat: Support setting and getting ArrayBuffers (`Uint8Array`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ storage.recrypt('hunter2')
 storage.recrypt(undefined)
 ```
 
+### Buffers
+
+```js
+storage.set('someToken', new Uint8Array([1, 100, 255]))
+const buffer = storage.getBuffer('someToken')
+console.log(buffer) // [1, 100, 255]
+```
+
 ## Testing with Jest
 
 A mocked MMKV instance is automatically used when testing with Jest, so you will be able to use `new MMKV()` as per normal in your tests. Refer to [example/test/MMKV.test.ts](example/test/MMKV.test.ts) for an example.

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(../MMKV/Core core)
 
 include_directories(
         ../MMKV/Core
+        ../cpp
         "${NODE_MODULES_DIR}/react-native/React"
         "${NODE_MODULES_DIR}/react-native/React/Base"
         "${NODE_MODULES_DIR}/react-native/ReactCommon/jsi"
@@ -14,7 +15,7 @@ include_directories(
 
 if(${REACT_NATIVE_VERSION} LESS 66)
         file(
-                TO_CMAKE_PATH 
+                TO_CMAKE_PATH
                 "${NODE_MODULES_DIR}/react-native/ReactCommon/jsi/jsi/jsi.cpp"
                 INCLUDE_JSI_CPP
         )
@@ -24,6 +25,7 @@ add_library(reactnativemmkv  # <-- Library name
         SHARED
         src/main/cpp/cpp-adapter.cpp
         src/main/cpp/MmkvHostObject.cpp
+        ../cpp/TypedArray.cpp
         ${INCLUDE_JSI_CPP} # only on older RN versions
 )
 

--- a/android/src/main/cpp/MmkvHostObject.cpp
+++ b/android/src/main/cpp/MmkvHostObject.cpp
@@ -194,7 +194,7 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
         if (hasValue) {
           auto length = buffer.length();
           TypedArray<TypedArrayKind::Uint8Array> array(runtime, length);
-          unsigned char* data = (unsigned char*) buffer.getPtr();
+          auto data = static_cast<const unsigned char*>(buffer.getPtr());
           std::vector<unsigned char> vector(length);
           vector.assign(data, data + length);
           array.update(runtime, vector);

--- a/android/src/main/cpp/MmkvHostObject.cpp
+++ b/android/src/main/cpp/MmkvHostObject.cpp
@@ -7,9 +7,11 @@
 //
 
 #include "MmkvHostObject.h"
+#include "TypedArray.h"
 #include <MMKV.h>
 #include <android/log.h>
 #include <string>
+#include <vector>
 
 MmkvHostObject::MmkvHostObject(const std::string& instanceId, std::string path, std::string cryptKey) {
   __android_log_print(ANDROID_LOG_INFO, "RNMMKV", "Creating MMKV instance \"%s\"... (Path: %s, Encryption-Key: %s)",
@@ -65,16 +67,37 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
       }
 
       auto keyName = arguments[0].getString(runtime).utf8(runtime);
+
       if (arguments[1].isBool()) {
+        // bool
         instance->set(arguments[1].getBool(), keyName);
       } else if (arguments[1].isNumber()) {
+        // number
         instance->set(arguments[1].getNumber(), keyName);
       } else if (arguments[1].isString()) {
+        // string
         auto stringValue = arguments[1].getString(runtime).utf8(runtime);
         instance->set(stringValue, keyName);
+      } else if (arguments[1].isObject()) {
+        // object
+        auto object = arguments[1].asObject(runtime);
+        if (isTypedArray(runtime, object)) {
+          // Uint8Array
+          auto typedArray = getTypedArray(runtime, object);
+          auto bufferValue = typedArray.getBuffer(runtime);
+          mmkv::MMBuffer buffer(bufferValue.data(runtime),
+                                bufferValue.size(runtime),
+                                mmkv::MMBufferCopyFlag::MMBufferNoCopy);
+          instance->set(buffer, keyName);
+        } else {
+          // unknown object
+          throw jsi::JSError(runtime, "MMKV::set: 'value' argument is an object, but not of type Uint8Array!");
+        }
       } else {
-        throw jsi::JSError(runtime, "MMKV::set: 'value' argument is not of type bool, number or string!");
+        // unknown type
+        throw jsi::JSError(runtime, "MMKV::set: 'value' argument is not of type bool, number, string or buffer!");
       }
+
       return jsi::Value::undefined();
     });
   }
@@ -150,6 +173,37 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
       }
     });
   }
+
+
+    if (propName == "getBuffer") {
+        // MMKV.getBuffer(key: string)
+        return jsi::Function::createFromHostFunction(runtime,
+                                                     jsi::PropNameID::forAscii(runtime, funcName),
+                                                     1,  // key
+                                                     [this](jsi::Runtime& runtime,
+                                                            const jsi::Value& thisValue,
+                                                            const jsi::Value* arguments,
+                                                            size_t count) -> jsi::Value {
+        if (!arguments[0].isString()) {
+          throw jsi::JSError(runtime, "First argument ('key') has to be of type string!");
+        }
+
+        auto keyName = arguments[0].getString(runtime).utf8(runtime);
+        mmkv::MMBuffer buffer;
+        bool hasValue = instance->getBytes(keyName, buffer);
+        if (hasValue) {
+          auto length = buffer.length();
+          TypedArray<TypedArrayKind::Uint8Array> array(runtime, length);
+          unsigned char* data = (unsigned char*) buffer.getPtr();
+          std::vector<unsigned char> vector(length);
+          vector.assign(data, data + length);
+          array.update(runtime, vector);
+          return array;
+        } else {
+          return jsi::Value::undefined();
+        }
+      });
+    }
 
   if (propName == "contains") {
     // MMKV.contains(key: string)

--- a/cpp/TypedArray.cpp
+++ b/cpp/TypedArray.cpp
@@ -1,0 +1,341 @@
+//
+//  TypedArray.cpp
+//  react-native-mmkv
+//
+//  Created by Marc Rousavy on 11.10.2022.
+//  Originally created by Expo (expo-gl)
+//
+
+#include "TypedArray.h"
+
+#include <unordered_map>
+
+template <TypedArrayKind T>
+using ContentType = typename typedArrayTypeMap<T>::type;
+
+enum class Prop
+{
+    Buffer,            // "buffer"
+    Constructor,       // "constructor"
+    Name,              // "name"
+    Proto,             // "__proto__"
+    Length,            // "length"
+    ByteLength,        // "byteLength"
+    ByteOffset,        // "offset"
+    IsView,            // "isView"
+    ArrayBuffer,       // "ArrayBuffer"
+    Int8Array,         // "Int8Array"
+    Int16Array,        // "Int16Array"
+    Int32Array,        // "Int32Array"
+    Uint8Array,        // "Uint8Array"
+    Uint8ClampedArray, // "Uint8ClampedArray"
+    Uint16Array,       // "Uint16Array"
+    Uint32Array,       // "Uint32Array"
+    Float32Array,      // "Float32Array"
+    Float64Array,      // "Float64Array"
+};
+
+class PropNameIDCache
+{
+public:
+    const jsi::PropNameID &get(jsi::Runtime &runtime, Prop prop)
+    {
+        if (!this->props[prop])
+        {
+            this->props[prop] = std::make_unique<jsi::PropNameID>(createProp(runtime, prop));
+        }
+        return *(this->props[prop]);
+    }
+
+    const jsi::PropNameID &getConstructorNameProp(jsi::Runtime &runtime, TypedArrayKind kind);
+
+    void invalidate()
+    {
+        props.erase(props.begin(), props.end());
+    }
+
+private:
+    std::unordered_map<Prop, std::unique_ptr<jsi::PropNameID>> props;
+
+    jsi::PropNameID createProp(jsi::Runtime &runtime, Prop prop);
+};
+
+PropNameIDCache propNameIDCache;
+
+void invalidateJsiPropNameIDCache()
+{
+    propNameIDCache.invalidate();
+}
+
+TypedArrayKind getTypedArrayKindForName(const std::string &name);
+
+TypedArrayBase::TypedArrayBase(jsi::Runtime &runtime, size_t size, TypedArrayKind kind)
+    : TypedArrayBase(
+          runtime,
+          runtime.global()
+              .getProperty(runtime, propNameIDCache.getConstructorNameProp(runtime, kind))
+              .asObject(runtime)
+              .asFunction(runtime)
+              .callAsConstructor(runtime, {static_cast<double>(size)})
+              .asObject(runtime)) {}
+
+TypedArrayBase::TypedArrayBase(jsi::Runtime &runtime, const jsi::Object &obj)
+    : jsi::Object(jsi::Value(runtime, obj).asObject(runtime)) {}
+
+TypedArrayKind TypedArrayBase::getKind(jsi::Runtime &runtime) const
+{
+    auto constructorName = this->getProperty(runtime, propNameIDCache.get(runtime, Prop::Constructor))
+                               .asObject(runtime)
+                               .getProperty(runtime, propNameIDCache.get(runtime, Prop::Name))
+                               .asString(runtime)
+                               .utf8(runtime);
+    return getTypedArrayKindForName(constructorName);
+};
+
+size_t TypedArrayBase::size(jsi::Runtime &runtime) const
+{
+    return getProperty(runtime, propNameIDCache.get(runtime, Prop::Length)).asNumber();
+}
+
+size_t TypedArrayBase::length(jsi::Runtime &runtime) const
+{
+    return getProperty(runtime, propNameIDCache.get(runtime, Prop::Length)).asNumber();
+}
+
+size_t TypedArrayBase::byteLength(jsi::Runtime &runtime) const
+{
+    return getProperty(runtime, propNameIDCache.get(runtime, Prop::ByteLength)).asNumber();
+}
+
+size_t TypedArrayBase::byteOffset(jsi::Runtime &runtime) const
+{
+    return getProperty(runtime, propNameIDCache.get(runtime, Prop::ByteOffset)).asNumber();
+}
+
+bool TypedArrayBase::hasBuffer(jsi::Runtime &runtime) const
+{
+    auto buffer = getProperty(runtime, propNameIDCache.get(runtime, Prop::Buffer));
+    return buffer.isObject() && buffer.asObject(runtime).isArrayBuffer(runtime);
+}
+
+std::vector<uint8_t> TypedArrayBase::toVector(jsi::Runtime &runtime)
+{
+    auto start =
+        reinterpret_cast<uint8_t *>(getBuffer(runtime).data(runtime) + byteOffset(runtime));
+    auto end = start + byteLength(runtime);
+    return std::vector<uint8_t>(start, end);
+}
+
+jsi::ArrayBuffer TypedArrayBase::getBuffer(jsi::Runtime &runtime) const
+{
+    auto buffer = getProperty(runtime, propNameIDCache.get(runtime, Prop::Buffer));
+    if (buffer.isObject() && buffer.asObject(runtime).isArrayBuffer(runtime))
+    {
+        return buffer.asObject(runtime).getArrayBuffer(runtime);
+    }
+    else
+    {
+        throw std::runtime_error("no ArrayBuffer attached");
+    }
+}
+
+bool isTypedArray(jsi::Runtime &runtime, const jsi::Object &jsObj)
+{
+    auto jsVal = runtime.global()
+                     .getProperty(runtime, propNameIDCache.get(runtime, Prop::ArrayBuffer))
+                     .asObject(runtime)
+                     .getProperty(runtime, propNameIDCache.get(runtime, Prop::IsView))
+                     .asObject(runtime)
+                     .asFunction(runtime)
+                     .callWithThis(runtime, runtime.global(), {jsi::Value(runtime, jsObj)});
+    if (jsVal.isBool())
+    {
+        return jsVal.getBool();
+    }
+    else
+    {
+        throw std::runtime_error("value is not a boolean");
+    }
+}
+
+TypedArrayBase getTypedArray(jsi::Runtime &runtime, const jsi::Object &jsObj)
+{
+    auto jsVal = runtime.global()
+                     .getProperty(runtime, propNameIDCache.get(runtime, Prop::ArrayBuffer))
+                     .asObject(runtime)
+                     .getProperty(runtime, propNameIDCache.get(runtime, Prop::IsView))
+                     .asObject(runtime)
+                     .asFunction(runtime)
+                     .callWithThis(runtime, runtime.global(), {jsi::Value(runtime, jsObj)});
+    if (jsVal.isBool())
+    {
+        return TypedArrayBase(runtime, jsObj);
+    }
+    else
+    {
+        throw std::runtime_error("value is not a boolean");
+    }
+}
+
+std::vector<uint8_t> arrayBufferToVector(jsi::Runtime &runtime, jsi::Object &jsObj)
+{
+    if (!jsObj.isArrayBuffer(runtime))
+    {
+        throw std::runtime_error("Object is not an ArrayBuffer");
+    }
+    auto jsArrayBuffer = jsObj.getArrayBuffer(runtime);
+
+    uint8_t *dataBlock = jsArrayBuffer.data(runtime);
+    size_t blockSize =
+        jsArrayBuffer.getProperty(runtime, propNameIDCache.get(runtime, Prop::ByteLength)).asNumber();
+    return std::vector<uint8_t>(dataBlock, dataBlock + blockSize);
+}
+
+void arrayBufferUpdate(
+    jsi::Runtime &runtime,
+    jsi::ArrayBuffer &buffer,
+    std::vector<uint8_t> data,
+    size_t offset)
+{
+    uint8_t *dataBlock = buffer.data(runtime);
+    size_t blockSize = buffer.size(runtime);
+    if (data.size() > blockSize)
+    {
+        throw jsi::JSError(runtime, "ArrayBuffer is to small to fit data");
+    }
+    std::copy(data.begin(), data.end(), dataBlock + offset);
+}
+
+template <TypedArrayKind T>
+TypedArray<T>::TypedArray(jsi::Runtime &runtime, size_t size) : TypedArrayBase(runtime, size, T){};
+
+template <TypedArrayKind T>
+TypedArray<T>::TypedArray(jsi::Runtime &runtime, std::vector<ContentType<T>> data)
+    : TypedArrayBase(runtime, data.size(), T)
+{
+    update(runtime, data);
+};
+
+template <TypedArrayKind T>
+TypedArray<T>::TypedArray(TypedArrayBase &&base) : TypedArrayBase(std::move(base)) {}
+
+template <TypedArrayKind T>
+std::vector<ContentType<T>> TypedArray<T>::toVector(jsi::Runtime &runtime)
+{
+    auto start =
+        reinterpret_cast<ContentType<T> *>(getBuffer(runtime).data(runtime) + byteOffset(runtime));
+    auto end = start + size(runtime);
+    return std::vector<ContentType<T>>(start, end);
+}
+
+template <TypedArrayKind T>
+void TypedArray<T>::update(jsi::Runtime &runtime, const std::vector<ContentType<T>> &data)
+{
+    if (data.size() != size(runtime))
+    {
+        throw jsi::JSError(runtime, "TypedArray can only be updated with a vector of the same size");
+    }
+    uint8_t *rawData = getBuffer(runtime).data(runtime) + byteOffset(runtime);
+    std::copy(data.begin(), data.end(), reinterpret_cast<ContentType<T> *>(rawData));
+}
+
+const jsi::PropNameID &PropNameIDCache::getConstructorNameProp(
+    jsi::Runtime &runtime,
+    TypedArrayKind kind)
+{
+    switch (kind)
+    {
+    case TypedArrayKind::Int8Array:
+        return get(runtime, Prop::Int8Array);
+    case TypedArrayKind::Int16Array:
+        return get(runtime, Prop::Int16Array);
+    case TypedArrayKind::Int32Array:
+        return get(runtime, Prop::Int32Array);
+    case TypedArrayKind::Uint8Array:
+        return get(runtime, Prop::Uint8Array);
+    case TypedArrayKind::Uint8ClampedArray:
+        return get(runtime, Prop::Uint8ClampedArray);
+    case TypedArrayKind::Uint16Array:
+        return get(runtime, Prop::Uint16Array);
+    case TypedArrayKind::Uint32Array:
+        return get(runtime, Prop::Uint32Array);
+    case TypedArrayKind::Float32Array:
+        return get(runtime, Prop::Float32Array);
+    case TypedArrayKind::Float64Array:
+        return get(runtime, Prop::Float64Array);
+    }
+}
+
+jsi::PropNameID PropNameIDCache::createProp(jsi::Runtime &runtime, Prop prop)
+{
+    auto create = [&](const std::string &propName)
+    {
+        return jsi::PropNameID::forUtf8(runtime, propName);
+    };
+    switch (prop)
+    {
+    case Prop::Buffer:
+        return create("buffer");
+    case Prop::Constructor:
+        return create("constructor");
+    case Prop::Name:
+        return create("name");
+    case Prop::Proto:
+        return create("__proto__");
+    case Prop::Length:
+        return create("length");
+    case Prop::ByteLength:
+        return create("byteLength");
+    case Prop::ByteOffset:
+        return create("byteOffset");
+    case Prop::IsView:
+        return create("isView");
+    case Prop::ArrayBuffer:
+        return create("ArrayBuffer");
+    case Prop::Int8Array:
+        return create("Int8Array");
+    case Prop::Int16Array:
+        return create("Int16Array");
+    case Prop::Int32Array:
+        return create("Int32Array");
+    case Prop::Uint8Array:
+        return create("Uint8Array");
+    case Prop::Uint8ClampedArray:
+        return create("Uint8ClampedArray");
+    case Prop::Uint16Array:
+        return create("Uint16Array");
+    case Prop::Uint32Array:
+        return create("Uint32Array");
+    case Prop::Float32Array:
+        return create("Float32Array");
+    case Prop::Float64Array:
+        return create("Float64Array");
+    }
+}
+
+std::unordered_map<std::string, TypedArrayKind> nameToKindMap = {
+    {"Int8Array", TypedArrayKind::Int8Array},
+    {"Int16Array", TypedArrayKind::Int16Array},
+    {"Int32Array", TypedArrayKind::Int32Array},
+    {"Uint8Array", TypedArrayKind::Uint8Array},
+    {"Uint8ClampedArray", TypedArrayKind::Uint8ClampedArray},
+    {"Uint16Array", TypedArrayKind::Uint16Array},
+    {"Uint32Array", TypedArrayKind::Uint32Array},
+    {"Float32Array", TypedArrayKind::Float32Array},
+    {"Float64Array", TypedArrayKind::Float64Array},
+};
+
+TypedArrayKind getTypedArrayKindForName(const std::string &name)
+{
+    return nameToKindMap.at(name);
+}
+
+template class TypedArray<TypedArrayKind::Int8Array>;
+template class TypedArray<TypedArrayKind::Int16Array>;
+template class TypedArray<TypedArrayKind::Int32Array>;
+template class TypedArray<TypedArrayKind::Uint8Array>;
+template class TypedArray<TypedArrayKind::Uint8ClampedArray>;
+template class TypedArray<TypedArrayKind::Uint16Array>;
+template class TypedArray<TypedArrayKind::Uint32Array>;
+template class TypedArray<TypedArrayKind::Float32Array>;
+template class TypedArray<TypedArrayKind::Float64Array>;

--- a/cpp/TypedArray.h
+++ b/cpp/TypedArray.h
@@ -1,0 +1,175 @@
+//
+//  TypedArray.h
+//  react-native-mmkv
+//
+//  Created by Marc Rousavy on 11.10.2022.
+//  Originally created by Expo (expo-gl)
+//
+
+#pragma once
+
+#include <jsi/jsi.h>
+
+namespace jsi = facebook::jsi;
+
+enum class TypedArrayKind
+{
+    Int8Array,
+    Int16Array,
+    Int32Array,
+    Uint8Array,
+    Uint8ClampedArray,
+    Uint16Array,
+    Uint32Array,
+    Float32Array,
+    Float64Array,
+};
+
+template <TypedArrayKind T>
+class TypedArray;
+
+template <TypedArrayKind T>
+struct typedArrayTypeMap;
+template <>
+struct typedArrayTypeMap<TypedArrayKind::Int8Array>
+{
+    typedef int8_t type;
+};
+template <>
+struct typedArrayTypeMap<TypedArrayKind::Int16Array>
+{
+    typedef int16_t type;
+};
+template <>
+struct typedArrayTypeMap<TypedArrayKind::Int32Array>
+{
+    typedef int32_t type;
+};
+template <>
+struct typedArrayTypeMap<TypedArrayKind::Uint8Array>
+{
+    typedef uint8_t type;
+};
+template <>
+struct typedArrayTypeMap<TypedArrayKind::Uint8ClampedArray>
+{
+    typedef uint8_t type;
+};
+template <>
+struct typedArrayTypeMap<TypedArrayKind::Uint16Array>
+{
+    typedef uint16_t type;
+};
+template <>
+struct typedArrayTypeMap<TypedArrayKind::Uint32Array>
+{
+    typedef uint32_t type;
+};
+template <>
+struct typedArrayTypeMap<TypedArrayKind::Float32Array>
+{
+    typedef float type;
+};
+template <>
+struct typedArrayTypeMap<TypedArrayKind::Float64Array>
+{
+    typedef double type;
+};
+
+void invalidateJsiPropNameIDCache();
+
+class TypedArrayBase : public jsi::Object
+{
+public:
+    template <TypedArrayKind T>
+    using ContentType = typename typedArrayTypeMap<T>::type;
+
+    TypedArrayBase(jsi::Runtime &, size_t, TypedArrayKind);
+    TypedArrayBase(jsi::Runtime &, const jsi::Object &);
+    TypedArrayBase(TypedArrayBase &&) = default;
+    TypedArrayBase &operator=(TypedArrayBase &&) = default;
+
+    TypedArrayKind getKind(jsi::Runtime &runtime) const;
+
+    template <TypedArrayKind T>
+    TypedArray<T> get(jsi::Runtime &runtime) const &;
+    template <TypedArrayKind T>
+    TypedArray<T> get(jsi::Runtime &runtime) &&;
+    template <TypedArrayKind T>
+    TypedArray<T> as(jsi::Runtime &runtime) const &;
+    template <TypedArrayKind T>
+    TypedArray<T> as(jsi::Runtime &runtime) &&;
+
+    size_t size(jsi::Runtime &runtime) const;
+    size_t length(jsi::Runtime &runtime) const;
+    size_t byteLength(jsi::Runtime &runtime) const;
+    size_t byteOffset(jsi::Runtime &runtime) const;
+    bool hasBuffer(jsi::Runtime &runtime) const;
+
+    std::vector<uint8_t> toVector(jsi::Runtime &runtime);
+    jsi::ArrayBuffer getBuffer(jsi::Runtime &runtime) const;
+
+private:
+    template <TypedArrayKind>
+    friend class TypedArray;
+};
+
+bool isTypedArray(jsi::Runtime &runtime, const jsi::Object &jsObj);
+TypedArrayBase getTypedArray(jsi::Runtime &runtime, const jsi::Object &jsObj);
+
+std::vector<uint8_t> arrayBufferToVector(jsi::Runtime &runtime, jsi::Object &jsObj);
+void arrayBufferUpdate(
+    jsi::Runtime &runtime,
+    jsi::ArrayBuffer &buffer,
+    std::vector<uint8_t> data,
+    size_t offset);
+
+template <TypedArrayKind T>
+class TypedArray : public TypedArrayBase
+{
+public:
+    TypedArray(jsi::Runtime &runtime, size_t size);
+    TypedArray(jsi::Runtime &runtime, std::vector<ContentType<T>> data);
+    TypedArray(TypedArrayBase &&base);
+    TypedArray(TypedArray &&) = default;
+    TypedArray &operator=(TypedArray &&) = default;
+
+    std::vector<ContentType<T>> toVector(jsi::Runtime &runtime);
+    void update(jsi::Runtime &runtime, const std::vector<ContentType<T>> &data);
+};
+
+template <TypedArrayKind T>
+TypedArray<T> TypedArrayBase::get(jsi::Runtime &runtime) const &
+{
+    assert(getKind(runtime) == T);
+    (void)runtime; // when assert is disabled we need to mark this as used
+    return TypedArray<T>(jsi::Value(runtime, jsi::Value(runtime, *this).asObject(runtime)));
+}
+
+template <TypedArrayKind T>
+TypedArray<T> TypedArrayBase::get(jsi::Runtime &runtime) &&
+{
+    assert(getKind(runtime) == T);
+    (void)runtime; // when assert is disabled we need to mark this as used
+    return TypedArray<T>(std::move(*this));
+}
+
+template <TypedArrayKind T>
+TypedArray<T> TypedArrayBase::as(jsi::Runtime &runtime) const &
+{
+    if (getKind(runtime) != T)
+    {
+        throw jsi::JSError(runtime, "Object is not a TypedArray");
+    }
+    return get<T>(runtime);
+}
+
+template <TypedArrayKind T>
+TypedArray<T> TypedArrayBase::as(jsi::Runtime &runtime) &&
+{
+    if (getKind(runtime) != T)
+    {
+        throw jsi::JSError(runtime, "Object is not a TypedArray");
+    }
+    return std::move(*this).get<T>(runtime);
+}

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -413,7 +413,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 6a05173dc0142abc582bd4edd2d23146b8cc218a
   React-jsinspector: be95ad424ba9f7b817aff22732eb9b1b810a000a
   React-logger: 9a9cd87d4ea681ae929b32ef580638ff1b50fb24
-  react-native-mmkv: 1265a348a4711097ba29c8bcefd5971f48220f2b
+  react-native-mmkv: 442bce2fef7f7c4a9b7382e9a14ee9d26b8e04ee
   React-perflogger: 1f554c2b684e2f484f9edcdfdaeedab039fbaca8
   React-RCTActionSheet: 610d5a5d71ab4808734782c8bca6a12ec3563672
   React-RCTAnimation: ec6ed97370ace32724c253f29f0586cafcab8126

--- a/ios/Mmkv.xcodeproj/project.pbxproj
+++ b/ios/Mmkv.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		5E555C0D2413F4C50049A1A2 /* Mmkv.mm in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* Mmkv.mm */; };
 		B81384EA26E23A8500A8507D /* MmkvHostObject.mm in Sources */ = {isa = PBXBuildFile; fileRef = B81384E926E23A8500A8507D /* MmkvHostObject.mm */; };
+		B8A8A9BE28F5797400345076 /* MmkvModule.mm in Sources */ = {isa = PBXBuildFile; fileRef = B8A8A9BD28F5797400345076 /* MmkvModule.mm */; };
 		B8CC270225E65597009808A2 /* JSIUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = B8CC270125E65597009808A2 /* JSIUtils.mm */; };
 /* End PBXBuildFile section */
 
@@ -26,10 +26,11 @@
 
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libMmkv.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMmkv.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		B3E7B5891CC2AC0600A0062D /* Mmkv.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Mmkv.mm; sourceTree = "<group>"; };
 		B81384E926E23A8500A8507D /* MmkvHostObject.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MmkvHostObject.mm; sourceTree = "<group>"; };
 		B81384EB26E23A8D00A8507D /* MmkvHostObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MmkvHostObject.h; sourceTree = "<group>"; };
-		B865949C25E63C5C002102DB /* Mmkv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Mmkv.h; sourceTree = "<group>"; };
+		B8A8A9BC28F5797400345076 /* MmkvModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MmkvModule.h; sourceTree = "<group>"; };
+		B8A8A9BD28F5797400345076 /* MmkvModule.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MmkvModule.mm; sourceTree = "<group>"; };
+		B8A8A9BF28F5798100345076 /* cpp */ = {isa = PBXFileReference; lastKnownFileType = folder; name = cpp; path = ../cpp; sourceTree = "<group>"; };
 		B8CC270125E65597009808A2 /* JSIUtils.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSIUtils.mm; sourceTree = "<group>"; };
 		B8CC270425E655AD009808A2 /* JSIUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSIUtils.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -60,8 +61,9 @@
 				B81384E926E23A8500A8507D /* MmkvHostObject.mm */,
 				B8CC270425E655AD009808A2 /* JSIUtils.h */,
 				B8CC270125E65597009808A2 /* JSIUtils.mm */,
-				B865949C25E63C5C002102DB /* Mmkv.h */,
-				B3E7B5891CC2AC0600A0062D /* Mmkv.mm */,
+				B8A8A9BC28F5797400345076 /* MmkvModule.h */,
+				B8A8A9BD28F5797400345076 /* MmkvModule.mm */,
+				B8A8A9BF28F5798100345076 /* cpp */,
 				134814211AA4EA7D00B7C361 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -123,8 +125,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5E555C0D2413F4C50049A1A2 /* Mmkv.mm in Sources */,
 				B81384EA26E23A8500A8507D /* MmkvHostObject.mm in Sources */,
+				B8A8A9BE28F5797400345076 /* MmkvModule.mm in Sources */,
 				B8CC270225E65597009808A2 /* JSIUtils.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/MmkvHostObject.mm
+++ b/ios/MmkvHostObject.mm
@@ -9,6 +9,8 @@
 #import <Foundation/Foundation.h>
 #import "MmkvHostObject.h"
 #import "JSIUtils.h"
+#import "TypedArray.h"
+#import <vector>
 
 MmkvHostObject::MmkvHostObject(NSString* instanceId, NSString* path, NSString* cryptKey)
 {
@@ -81,6 +83,20 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
         // Set as UTF-8 string
         auto stringValue = convertJSIStringToNSString(runtime, arguments[1].getString(runtime));
         [instance setString:stringValue forKey:keyName];
+      } else if (arguments[1].isObject()) {
+        // object
+        auto object = arguments[1].asObject(runtime);
+        if (isTypedArray(runtime, object)) {
+          // Uint8Array
+          auto typedArray = getTypedArray(runtime, object);
+          auto bufferValue = typedArray.getBuffer(runtime);
+          auto data = [[NSData alloc] initWithBytes:bufferValue.data(runtime)
+                                             length:bufferValue.length(runtime)];
+          [instance setData:data forKey:keyName];
+        } else {
+          // unknown object
+          throw jsi::JSError(runtime, "MMKV::set: 'value' argument is an object, but not of type Uint8Array!");
+        }
       } else {
         // Invalid type
         throw jsi::JSError(runtime, "Second argument ('value') has to be of type bool, number or string!");
@@ -136,7 +152,7 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
       }
     });
   }
-
+    
   if (propName == "getNumber") {
     // MMKV.getNumber(key: string)
     return jsi::Function::createFromHostFunction(runtime,
@@ -155,6 +171,34 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
       auto value = [instance getDoubleForKey:keyName defaultValue:0.0 hasValue:&hasValue];
       if (hasValue) {
         return jsi::Value(value);
+      } else {
+        return jsi::Value::undefined();
+      }
+    });
+  }
+
+  if (propName == "getBuffer") {
+    // MMKV.getBuffer(key: string)
+    return jsi::Function::createFromHostFunction(runtime,
+                                                 jsi::PropNameID::forAscii(runtime, funcName),
+                                                 1,  // key
+                                                 [this](jsi::Runtime& runtime,
+                                                        const jsi::Value& thisValue,
+                                                        const jsi::Value* arguments,
+                                                        size_t count) -> jsi::Value {
+      if (!arguments[0].isString()) {
+        throw jsi::JSError(runtime, "First argument ('key') has to be of type string!");
+      }
+
+      auto keyName = convertJSIStringToNSString(runtime, arguments[0].getString(runtime));
+      auto data = [instance getDataForKey:keyName];
+      if (data != nil) {
+        TypedArray<TypedArrayKind::Uint8Array> array(runtime, data.length);
+        auto charArray = static_cast<const unsigned char*>([data bytes]);
+        std::vector<unsigned char> vector(data.length);
+        vector.assign(charArray, charArray + data.length);
+        array.update(runtime, vector);
+        return array;
       } else {
         return jsi::Value::undefined();
       }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "android/build.gradle",
     "android/gradle.properties",
     "android/CMakeLists.txt",
+    "cpp",
     "MMKV/Core",
     "lib/commonjs",
     "lib/module",

--- a/react-native-mmkv.podspec
+++ b/react-native-mmkv.podspec
@@ -17,7 +17,8 @@ Pod::Spec.new do |s|
   # Note how this does not include headers, since those can nameclash.
   s.source_files = [
     "ios/**/*.{m,mm}",
-    "ios/MmkvModule.h"
+    "ios/MmkvModule.h",
+    "cpp/**/*.{h,cpp}"
   ]
   # Any private headers that are not globally unique should be mentioned here.
   # Otherwise there will be a nameclash, since CocoaPods flattens out any header directories

--- a/src/MMKV.ts
+++ b/src/MMKV.ts
@@ -51,7 +51,7 @@ interface MMKVInterface {
   /**
    * Set a value for the given `key`.
    */
-  set: (key: string, value: boolean | string | number) => void;
+  set: (key: string, value: boolean | string | number | Uint8Array) => void;
   /**
    * Get the boolean value for the given `key`, or `undefined` if it does not exist.
    *
@@ -70,6 +70,12 @@ interface MMKVInterface {
    * @default undefined
    */
   getNumber: (key: string) => number | undefined;
+  /**
+   * Get a raw buffer of unsigned 8-bit (0-255) data.
+   *
+   * @default undefined
+   */
+  getBuffer: (key: string) => Uint8Array | undefined;
   /**
    * Checks whether the given `key` is being stored in this MMKV instance.
    */
@@ -116,6 +122,7 @@ export type NativeMMKV = Pick<
   | 'getBoolean'
   | 'getNumber'
   | 'getString'
+  | 'getBuffer'
   | 'set'
   | 'recrypt'
 >;
@@ -168,7 +175,7 @@ export class MMKV implements MMKVInterface {
     }
   }
 
-  set(key: string, value: boolean | string | number): void {
+  set(key: string, value: boolean | string | number | Uint8Array): void {
     const func = this.getFunctionFromCache('set');
     func(key, value);
 
@@ -184,6 +191,10 @@ export class MMKV implements MMKVInterface {
   }
   getNumber(key: string): number | undefined {
     const func = this.getFunctionFromCache('getNumber');
+    return func(key);
+  }
+  getBuffer(key: string): Uint8Array | undefined {
+    const func = this.getFunctionFromCache('getBuffer');
     return func(key);
   }
   contains(key: string): boolean {

--- a/src/createMMKV.mock.ts
+++ b/src/createMMKV.mock.ts
@@ -2,7 +2,7 @@ import type { NativeMMKV } from 'react-native-mmkv';
 
 /* Mock MMKV instance for use in tests */
 export const createMockMMKV = (): NativeMMKV => {
-  const storage = new Map<string, string | boolean | number>();
+  const storage = new Map<string, string | boolean | number | Uint8Array>();
 
   return {
     clearAll: () => storage.clear(),
@@ -19,6 +19,10 @@ export const createMockMMKV = (): NativeMMKV => {
     getBoolean: (key) => {
       const result = storage.get(key);
       return typeof result === 'boolean' ? result : undefined;
+    },
+    getBuffer: (key) => {
+      const result = storage.get(key);
+      return result instanceof Uint8Array ? result : undefined;
     },
     getAllKeys: () => Array.from(storage.keys()),
     contains: (key) => storage.has(key),

--- a/src/createMMKV.web.ts
+++ b/src/createMMKV.web.ts
@@ -1,5 +1,6 @@
 /* global localStorage */
 import type { MMKVConfiguration, NativeMMKV } from 'react-native-mmkv';
+import { createTextEncoder } from './createTextEncoder';
 
 const canUseDOM =
   typeof window !== 'undefined' && window.document?.createElement != null;
@@ -29,6 +30,8 @@ export const createMMKV = (config: MMKVConfiguration): NativeMMKV => {
     return domStorage;
   };
 
+  const textEncoder = createTextEncoder();
+
   return {
     clearAll: () => storage().clear(),
     delete: (key) => storage().removeItem(key),
@@ -43,6 +46,11 @@ export const createMMKV = (config: MMKVConfiguration): NativeMMKV => {
       const value = storage().getItem(key);
       if (value == null) return undefined;
       return value === 'true';
+    },
+    getBuffer: (key) => {
+      const value = storage().getItem(key);
+      if (value == null) return undefined;
+      return textEncoder.encode(value);
     },
     getAllKeys: () => Object.keys(storage()),
     contains: (key) => storage().getItem(key) != null,

--- a/src/createTextEncoder.ts
+++ b/src/createTextEncoder.ts
@@ -1,0 +1,16 @@
+/* global TextEncoder */
+export function createTextEncoder(): TextEncoder {
+  if (global.TextEncoder != null) {
+    return new global.TextEncoder();
+  } else {
+    return {
+      encode: () => {
+        throw new Error('TextEncoder is not supported in this environment!');
+      },
+      encodeInto: () => {
+        throw new Error('TextEncoder is not supported in this environment!');
+      },
+      encoding: 'utf-8',
+    };
+  }
+}


### PR DESCRIPTION
## What

This PR adds support for ArrayBuffers (fixed: `Uint8Array`) for the get and set functions to MMKV.

The user can write raw binary data in the form of Uint8Arrays to the storage:

```ts
const storage = new MMKV()

const buffer = new Uint8Array([255, 255, 100, 100, 8, 8, 5])
storage.set('buffer', buffer)
```

And retrieve it again:

```ts
const storage = new MMKV()

const buffer = storage.getBuffer('buffer')
console.log(buffer)
```

## `Uint8Array` <> `ArrayBuffer`

To convert a `Uint8Array` to an `ArrayBuffer`:

```ts
const arrayBuffer = // ArrayBuffer...
const buffer = new Uint8Array(arrayBuffer)

// and other way around:

const buffer = storage.getBuffer('buffer')
const arrayBuffer = buffer.buffer
```

## Performance

Writing a Buffer to storage involves only a single copy operation. This means it's really fast.

Reading from storage is fast as well as we only copy once.

Reading and writing 100 kB (1024 * 100 Bytes) of data takes only around 2ms:

```ts
      storage.clearAll();
      // 100kB
      const buff = new Uint8Array(1024 * 100);
      buff.fill(100);
      {
        console.log('setting buff');
        const start = performance.now();
        storage.set('b', buff);
        const end = performance.now();
        console.log(`set buff in ${end - start}ms!`);
      }
      {
        console.log('getting buff');
        const start = performance.now();
        const b = storage.getBuffer('b');
        const end = performance.now();
        console.log(`got buff in ${end - start}ms! Size: ${b?.length}`);
      }
```

```
 LOG  setting buff
 LOG  set buff in 2.83058699965477ms!
 LOG  getting buff
 LOG  got buff in 1.9454819988459349ms! Size: 102400
```

## Fun Fact

You can ready every value as a Buffer. Even if they are stored as strings, numbers or booleans.