### PR TITLE
Remove deprecated dexOptions gradle property

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -107,10 +107,6 @@ android {
     }
   }
 
-  dexOptions {
-    javaMaxHeapSize "4g"
-  }
-
   externalNativeBuild {
     cmake {
       path "CMakeLists.txt"


### PR DESCRIPTION
This PR removes the deprecated gradle property `dexOptions`, which will be removed with Gradle 8.0.

Warning in Android Studio:
```
DSL element 'dexOptions' is obsolete and should be removed.
It will be removed in version 8.0 of the Android Gradle plugin.
Using it has no effect, and the AndroidGradle plugin optimizes dexing automatically.
Affected Modules: react-native-mmkv
```

Resolves #437 