### PR TITLE
bug: build crashes when new architecture is not enabled

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,9 @@ def isNewArchitectureEnabled() {
   return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
 }
 
-apply plugin: 'com.facebook.react'
+if (isNewArchitectureEnabled()) {
+  apply plugin: 'com.facebook.react'
+}
 apply plugin: 'com.android.library'
 
 def safeExtGet(prop, fallback) {


### PR DESCRIPTION
Should resolve https://github.com/mrousavy/react-native-mmkv/issues/497#issuecomment-1384902642

Opened a PR from the GitHub Web UI for the first time since it was a one-line change.