### PR TITLE
Add `codegenConfig` to `package.json` to prevent generating duplicate classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,5 +165,10 @@
         }
       ]
     ]
+  },
+  "codegenConfig": {
+    "name": "reactnativemmkv",
+    "type": "modules",
+    "jsSrcsDir": "./lib/module"
   }
 }


### PR DESCRIPTION
It seems like codegen will generate duplicated files if `codegenConfig` property is missing from `package.json` (meaning all view manager delegates and interfaces will be also generated under `react-native-mmkv/android/build/generated/source/codegen/react/viewmanagers`). This results in the build failing due to multiple definitions of the same classes.

I'm not exactly sure what `jsSrcsDir` should point to in this case. It doesn't really matter as long as the library doesn't depend on the generated code, but if it points to a non-existent directory the build will fail. Since files under `src` aren't included in the npm package, I figured the `lib/module` will do. Feel free to change it if you have other ideas.

Related issue: https://github.com/software-mansion/react-native-gesture-handler/issues/2382