### PR TITLE
feat: `fastWrites` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ import { MMKV } from 'react-native-mmkv'
 export const storage = new MMKV({
   id: `user-${userId}-storage`,
   path: `${USER_DIRECTORY}/storage`,
-  encryptionKey: 'hunter2'
+  encryptionKey: 'hunter2',
+  fastWrites: true
 })
 ```
 
@@ -115,6 +116,7 @@ The following values can be configured:
 * `id`: The MMKV instance's ID. If you want to use multiple instances, use different IDs. For example, you can separate the global app's storage and a logged-in user's storage. (required if `path` or `encryptionKey` fields are specified, otherwise defaults to: `'mmkv.default'`)
 * `path`: The MMKV instance's root path. By default, MMKV stores file inside `$(Documents)/mmkv/`. You can customize MMKV's root directory on MMKV initialization (documentation: [iOS](https://github.com/Tencent/MMKV/wiki/iOS_advance#customize-location) / [Android](https://github.com/Tencent/MMKV/wiki/android_advance#customize-location))
 * `encryptionKey`: The MMKV instance's encryption/decryption key. By default, MMKV stores all key-values in plain text on file, relying on iOS's/Android's sandbox to make sure the file is encrypted. Should you worry about information leaking, you can choose to encrypt MMKV. (documentation: [iOS](https://github.com/Tencent/MMKV/wiki/iOS_advance#encryption) / [Android](https://github.com/Tencent/MMKV/wiki/android_advance#encryption))
+* `fastWrites`: Configure fast writes for MMKV. When set to `true`, all calls to `set(..)` do not overwrite the previous value to avoid storage resizing, this speeds up write speed. Only enable this if you use a small MMKV storage, as this uses more RAM.
 
 ### Set
 

--- a/src/MMKV.ts
+++ b/src/MMKV.ts
@@ -44,9 +44,11 @@ export interface MMKVConfiguration {
   encryptionKey?: string;
   /**
    * Configure fast writes for MMKV.
-   * 
+   *
    * When set to `true`, all calls to `set(..)` do not overwrite the previous
    * value to avoid storage resizing, this speeds up writes.
+   *
+   * Only enable this if you use a small MMKV storage, as this uses more RAM.
    *
    * @default false
    */
@@ -151,9 +153,9 @@ export class MMKV implements MMKVInterface {
    * Creates a new MMKV instance with the given Configuration.
    * If no custom `id` is supplied, `'mmkv.default'` will be used.
    */
-  constructor(configuration: MMKVConfiguration = { id: 'mmkv.default', fastWrites: false }) {
+  constructor(configuration: MMKVConfiguration = { id: 'mmkv.default' }) {
     this.id = configuration.id;
-    this.fastWrites = configuration.fastWrites;
+    this.fastWrites = configuration.fastWrites ?? false;
     this.nativeInstance = isJest()
       ? createMockMMKV()
       : createMMKV(configuration);


### PR DESCRIPTION
Adds a `fastWrites` property to the MMKV constructor.

* When `true`, MMKV does not overwrite previous values when calling `set`. This is faster, but uses more memory.
* When `false`, MMKV deletes the previous value before calling `set`. This makes sure the storage size is always as small as possible, with the added performance cost of one delete call before setting. 

Before this PR, MMKV behaved as if `fastWrites` was set to `true` (i.e.; fast, but use more memory). Now after this PR, `fastWrites` is `false` by default, because users were complaining in #440 that the storage size grows too big.