### PR TITLE
feat: Support `id` on web

### DIFF
--- a/src/createMMKV.web.ts
+++ b/src/createMMKV.web.ts
@@ -29,6 +29,10 @@ export const createMMKV = (config: MMKVConfiguration): NativeMMKV => {
 
   const textEncoder = createTextEncoder();
 
+  if (config.id.indexOf('\\') !== -1) {
+    throw new Error('MMKV: `id` cannot contain the backslash character (`\\`)!');
+  }
+
   const keyPrefix = (config.id && config.id !== 'mmkv.default') ? `${config.id}\\` : null;
   const prefixedKey = (key: string) => {
     if (keyPrefix === null) return key;
@@ -38,7 +42,12 @@ export const createMMKV = (config: MMKVConfiguration): NativeMMKV => {
   return {
     clearAll: () => storage().clear(),
     delete: (key) => storage().removeItem(prefixedKey(key)),
-    set: (key, value) => storage().setItem(prefixedKey(key), value.toString()),
+    set: (key, value) => {
+      if (key.indexOf('\\') !== -1) {
+        throw new Error('MMKV: `key` cannot contain the backslash character (`\\`)!');
+      }
+      storage().setItem(prefixedKey(key), value.toString())
+    },
     getString: (key) => storage().getItem(prefixedKey(key)) ?? undefined,
     getNumber: (key) => {
       const value = storage().getItem(prefixedKey(key));


### PR DESCRIPTION
**I'm putting this PR up as a draft because I still need to put these changes through its paces in our codebase, but I would appreciate any feedback you might have in the interim.**

# Description
Local storage does not have a concept of separate stores in user code, this change emulates that behaviour by prefixing the keys in local storage with `id`.

This retains backwards compatibility with existing web MMKV stores by treating the the default `mmkv.default` id is as prefixless.

Fixes #520

# Questions I have
- **How can I exercise the web code in the unit tests?**
   The unit tests don't seem to exercise the `id` option, I'm open to extending the test coverage for this, but for this change it would probably also make sense to actually exercise the web code in tests.
- **Running `yarn lint` fails unexpectedly**
  ```
  Error: package.json » @react-native-community/eslint-config#overrides[2]:
        Environment key "jest/globals" is unknown
  ```
  It does fail on `master` like this too for me, so I'm not sure if this an issue with my local environment.