### PR TITLE
docs: Update deprecated `expo install` instructions to `npx expo install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ cd ios && pod install
 ### Expo
 
 ```sh
-expo install react-native-mmkv
-expo prebuild
+npx expo install react-native-mmkv
+npx expo prebuild
 ```
 
 ## Usage


### PR DESCRIPTION
Hi 👋

One thing I'd like to update and make it future-proof for Expo specific projects is to update the installation command from `expo install...` to `npx expo install...`. Since the latter refers to the new Expo CLI, which doesn't require any global package installation. For `expo install`, people will need to install the deprecated global cli (and we are not recommending that).