### PR TITLE
docs: note about `react-native` <-> `react-native-mmkv` versions compativility

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ yarn add react-native-mmkv
 cd ios && pod install
 ```
 
+**Note:** For `react-native` versions below `0.71`, use `react-native-mmkv` version `2.5.1`. Versions [`2.6.0`](https://github.com/mrousavy/react-native-mmkv/releases/tag/v2.6.0) and later require a minimum `react-native` version of `0.71`. 
+
 ### Expo
 
 ```sh


### PR DESCRIPTION
I needed to use this library in a project with a rather old version of `react-native` (`v0.65.3`, for that matter). Of course, I defaulted to the latest version because the documentation didn't tell me otherwise. Only after some time I found out that in my case I can't use the latest version. Other people apparently sometimes find this information the hard way, as in this [issue](https://github.com/mrousavy/react-native-mmkv/issues/500). So I decided it wouldn't hurt to make a note of it in the project README.
