### PR TITLE
feat(android): add support for upcoming react native 0.73

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,6 +46,7 @@ repositories {
 }
 
 android {
+  namespace = "com.reactnativemmkv"
   compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   // Used to override the NDK path/version on internal CI or by allowing

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactnativemmkv">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>


### PR DESCRIPTION
As per https://github.com/react-native-community/discussions-and-proposals/issues/671, this change is needed to support a future release of React Native.