### PR TITLE
feat(android): 🌟 add support for React Native 0.73

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,6 +46,7 @@ repositories {
 }
 
 android {
+  namespace = "com.reactnativemmkv"
   compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   // Used to override the NDK path/version on internal CI or by allowing

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactnativemmkv">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>


### PR DESCRIPTION
# Summary
Starting from React Native v0.73 , all libraries will need to be updated with these two one-liners due to Android Gradle Plugin upgrade
[discussions-671](https://github.com/react-native-community/discussions-and-proposals/issues/671)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |