### PR TITLE
fix: prevent console.warn spam in server environment

### DIFF
--- a/src/createMMKV.web.ts
+++ b/src/createMMKV.web.ts
@@ -26,8 +26,9 @@ export const createMMKV = (config: MMKVConfiguration): NativeMMKV => {
   if (config.path != null) {
     throw new Error("MMKV: 'path' is not supported on Web!");
   }
-
-  if (!hasAccessToLocalStorage()) {
+  
+  // The typeof window check prevents spam in Node server environments, such as Next.js server side props.
+  if (!hasAccessToLocalStorage() && typeof window !== "undefined") {
     console.warn(
       'MMKV: LocalStorage has been disabled. Your experience will be limited to in-memory storage!'
     );

--- a/src/createMMKV.web.ts
+++ b/src/createMMKV.web.ts
@@ -27,8 +27,8 @@ export const createMMKV = (config: MMKVConfiguration): NativeMMKV => {
     throw new Error("MMKV: 'path' is not supported on Web!");
   }
   
-  // The typeof window check prevents spam in Node server environments, such as Next.js server side props.
-  if (!hasAccessToLocalStorage() && typeof window !== "undefined") {
+  // canUseDOM check prevents spam in Node server environments, such as Next.js server side props.
+  if (!hasAccessToLocalStorage() && canUseDOM) {
     console.warn(
       'MMKV: LocalStorage has been disabled. Your experience will be limited to in-memory storage!'
     );


### PR DESCRIPTION
The latest version 2.10.0 added a good fallback strategy for browsers with disabled localStorage. The warning is also useful, but it tends to spam and flood the console/logs of Next.js/Node server environments. To address this, you can add a simple check to limit the console.log statement to the browser environment only.

Addresses a regression caused by https://github.com/mrousavy/react-native-mmkv/pull/533