### PR TITLE
Fix: "Failed to create MMKV instance" after reload/fast refresh with Expo Dev Client

### DIFF
--- a/ios/MmkvModule.mm
+++ b/ios/MmkvModule.mm
@@ -13,7 +13,13 @@ using namespace facebook;
 
 @implementation MmkvModule
 
+@synthesize bridge=_bridge;
+
 RCT_EXPORT_MODULE(MMKV)
+
+- (void)setBridge:(RCTBridge *)bridge {
+  _bridge = bridge;
+}
 
 + (NSString*)getPropertyAsStringOrNilFromObject:(jsi::Object&)object
                                    propertyName:(std::string)propertyName
@@ -25,8 +31,7 @@ RCT_EXPORT_MODULE(MMKV)
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install : (nullable NSString*)storageDirectory) {
   NSLog(@"Installing global.mmkvCreateNewInstance...");
-  RCTBridge* bridge = [RCTBridge currentBridge];
-  RCTCxxBridge* cxxBridge = (RCTCxxBridge*)bridge;
+  RCTCxxBridge* cxxBridge = (RCTCxxBridge*)_bridge;
   if (cxxBridge == nil) {
     return @false;
   }


### PR DESCRIPTION
Fixes #576 and #566
