### PR TITLE
fix: change boost download source in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -204,7 +204,7 @@ task createNativeDepsDirectories {
 
 task downloadBoost(dependsOn: createNativeDepsDirectories, type: Download) {
   def transformedVersion = BOOST_VERSION.replace("_", ".")
-  def srcUrl = "https://boostorg.jfrog.io/artifactory/main/release/${transformedVersion}/source/boost_${BOOST_VERSION}.tar.gz"
+  def srcUrl = "https://archives.boost.io/release/${transformedVersion}/source/boost_${BOOST_VERSION}.tar.gz"
   if (REACT_NATIVE_VERSION < 69) {
     srcUrl = "https://github.com/react-native-community/boost-for-react-native/releases/download/v${transformedVersion}-0/boost_${BOOST_VERSION}.tar.gz"
   }


### PR DESCRIPTION
### What
Synced boost download source link with React Native.
Commit : https://github.com/facebook/react-native/commit/7e721f09ad3dafed9f490f433b2ac613786c27b2

### Changes
This pull request primarily impacts the downloadBoost task within the build.gradle file. Specifically, the variable srcUrl is updated from `"https://boostorg.jfrog.io/artifactory/main/release/${transformedVersion}/source/boost_${BOOST_VERSION}.tar.gz"` to `"https://archives.boost.io/release/${transformedVersion}/source/boost_${BOOST_VERSION}.tar.gz".`



### Related issues
Link : https://github.com/mrousavy/react-native-mmkv/issues/617

