### PR TITLE
Use install_modules_dependencies in podspec

### DIFF
--- a/react-native-mmkv.podspec
+++ b/react-native-mmkv.podspec
@@ -28,5 +28,9 @@ Pod::Spec.new do |s|
   ]
 
   s.dependency "MMKV", ">= 1.3.3"
-  s.dependency "React-Core"
+  if respond_to?(:install_modules_dependencies, true)
+    install_modules_dependencies(s)
+  else
+    s.dependency "React-Core"
+  end
 end


### PR DESCRIPTION
Hi Marc 👋 😄 

When using `react-native-mmkv` with latest RN RC (0.74-RC.2), iOS fails to build due to some C++ errors that looked like header issues to me. This PR changes the Podspec to use the `install_modules_dependencies` function if available which solves this issue for me. 