### PR TITLE
fix: Use `.mock` extension for MMKV mocks

### DIFF
--- a/src/MMKV.ts
+++ b/src/MMKV.ts
@@ -1,6 +1,4 @@
 import { createMMKV } from './createMMKV';
-import { createMockMMKV } from './createMMKV.mock';
-import { isJest } from './PlatformChecker';
 
 interface Listener {
   remove: () => void;
@@ -29,8 +27,8 @@ export interface MMKVConfiguration {
    * ```ts
    * const temporaryStorage = new MMKV({ path: '/tmp/' })
    * ```
-   * 
-   * _Notice_: On iOS you can set the AppGroup bundle property to share the same storage between your app and its extensions. 
+   *
+   * _Notice_: On iOS you can set the AppGroup bundle property to share the same storage between your app and its extensions.
    * In this case `path` property will be ignored.
    * See more on MMKV configuration [here](https://github.com/Tencent/MMKV/wiki/iOS_tutorial#configuration).
    */
@@ -147,9 +145,7 @@ export class MMKV implements MMKVInterface {
    */
   constructor(configuration: MMKVConfiguration = { id: 'mmkv.default' }) {
     this.id = configuration.id;
-    this.nativeInstance = isJest()
-      ? createMockMMKV()
-      : createMMKV(configuration);
+    this.nativeInstance = createMMKV(configuration);
     this.functionCache = {};
   }
 

--- a/src/PlatformChecker.ts
+++ b/src/PlatformChecker.ts
@@ -1,7 +1,0 @@
-export function isJest(): boolean {
-  if (global.process == null) {
-    // In a WebBrowser/Electron the `process` variable does not exist
-    return false;
-  }
-  return process.env.JEST_WORKER_ID != null;
-}

--- a/src/createMMKV.mock.ts
+++ b/src/createMMKV.mock.ts
@@ -1,7 +1,8 @@
 import type { NativeMMKV } from 'react-native-mmkv';
+import { MMKVConfiguration } from 'react-native-mmkv';
 
 /* Mock MMKV instance for use in tests */
-export const createMockMMKV = (): NativeMMKV => {
+export const createMMKV = (_: MMKVConfiguration): NativeMMKV => {
   const storage = new Map<string, string | boolean | number | Uint8Array>();
 
   return {

--- a/test/hooks.test.tsx
+++ b/test/hooks.test.tsx
@@ -9,6 +9,8 @@ import {
 } from '@testing-library/react-native';
 import { MMKV, useMMKVNumber, useMMKVString } from '../src';
 
+jest.mock('../src/createMMKV', () => require('../src/createMMKV.mock.ts'));
+
 const mmkv = new MMKV();
 
 beforeEach(() => {


### PR DESCRIPTION
The issue I was having that when I was running metro in mock mode. isJest() returned false, so the createMMKV from the regular file was imported, but since I was running in mock mode. That file didn't exist, so createMMKV was undefined. 

Maybe I am missing something, but .mock files are supposed to replace their regular counterparts when running in mock mode. It doesn't make much sense to me to import from both and have a check to determine which to use. Instead, metro  should pick the one that is currently relevant. This is achieved by giving the functions the same name and only importing from the regular one. the .mock one is used when running in mock mode.
For jest to use the mock I have added jest.mock in the unit test. This feels like a more appropriate way to add a mock then changing the imports in the actual code. 

Alternatively, we could add a .mock for that platform checker that always returns true, that is how I initially patched it and a smaller change. 

I am not sure what the .web variant is for, I didn't want to remove it, since it is unrelated, but it does not appear to be used anywhere. 

This is my first PR to this repo, please let me know if I should do something else or in a different way.