### PR TITLE
docs: Update Jotai wrapper documentation to remove the double JSON.stringify() / JSON.parse()

### DIFF
--- a/docs/WRAPPER_JOTAI.md
+++ b/docs/WRAPPER_JOTAI.md
@@ -8,13 +8,13 @@ import { MMKV } from 'react-native-mmkv';
 
 const storage = new MMKV();
 
-function getItem<T>(key: string): T | null {
-  const value = storage.getString(key);
-  return value ? JSON.parse(value) : null;
+function getItem(key: string): string | null {
+  const value = storage.getString(key)
+  return value ? value : null
 }
 
-function setItem<T>(key: string, value: T): void {
-  storage.set(key, JSON.stringify(value));
+function setItem(key: string, value: string): void {
+  storage.set(key, value)
 }
 
 function removeItem(key: string): void {
@@ -38,10 +38,12 @@ export const atomWithMMKV = <T>(key: string, initialValue: T) =>
   );
 ```
 
-Then simply use `atomWithMMKV(..)` instead of `atom(..)` when creating an atom you'd like to persist accross app starts.
+Then simply use `atomWithMMKV(..)` instead of `atom(..)` when creating an atom you'd like to persist accross app starts. 
 
 ```ts
 const myAtom = atomWithMMKV('my-atom-key', 'value');
 ```
+
+*Note:* `createJSONStorage` handles `JSON.stringify()`/`JSON.parse()` when setting and returning the stored value.
 
 See the official Jotai doc here: https://jotai.org/docs/utils/atom-with-storage


### PR DESCRIPTION
`createJSONStorage` handles `JSON.string()`/`JSON.parse()` when setting and returning the stored value. The current documentation always results in a string being returned.