### PR TITLE
fix: Export `Mode` enum as value

### DIFF
--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,4 +1,4 @@
 export * from './MMKV';
 export * from './hooks';
 
-export type { Mode, Configuration } from './NativeMmkv';
+export { Mode, Configuration } from './NativeMmkv';


### PR DESCRIPTION
Previously it was only exported as a type, causing it to be undefined in release.

- Fixes https://github.com/mrousavy/react-native-mmkv/issues/691