### PR TITLE
chore: remove leftover code

### DIFF
--- a/package/android/CMakeLists.txt
+++ b/package/android/CMakeLists.txt
@@ -9,7 +9,6 @@ add_library(
         react-native-mmkv
         SHARED
         src/main/cpp/AndroidLogger.cpp
-        src/main/cpp/cpp-adapter.cpp
         ../cpp/MmkvHostObject.cpp
         ../cpp/NativeMmkvModule.cpp
 )

--- a/package/android/src/main/cpp/cpp-adapter.cpp
+++ b/package/android/src/main/cpp/cpp-adapter.cpp
@@ -1,7 +1,0 @@
-#include <jni.h>
-
-extern "C" JNIEXPORT jdouble JNICALL Java_com_mmkv_MmkvModule_nativeMultiply(JNIEnv* env,
-                                                                             jclass type, jdouble a,
-                                                                             jdouble b) {
-  return 5.0;
-}


### PR DESCRIPTION
## Summary
Since the mmkv was migrated to a pure c++ turbo module, there is no longer need for the adapter which anyway includes useless code