### PR TITLE
feat: If AppGroup defined in plist apply group dir.

### DIFF
--- a/package/cpp/MmkvHostObject.cpp
+++ b/package/cpp/MmkvHostObject.cpp
@@ -28,7 +28,21 @@ MmkvHostObject::MmkvHostObject(const facebook::react::MMKVConfig& config) {
   MMKVMode mode = getMMKVMode(config);
 
 #ifdef __APPLE__
-  instance = MMKV::mmkvWithID(config.id, mode, encryptionKeyPtr, pathPtr);
+#include <Foundation/Foundation.h>
+  NSString* appGroup = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"AppGroup"];
+  if (appGroup) {
+    MmkvLogger::log("RNMMKV", "Path ignored, AppGroup defined plist");
+    NSString* groupDir =
+        [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:appGroup]
+            .path;
+    const char* groupDirCStr = [groupDir UTF8String];
+    std::string groupDirStr(groupDirCStr);
+
+    instance = MMKV::mmkvWithID(config.id, mode, encryptionKeyPtr, &groupDirStr);
+
+  } else {
+    instance = MMKV::mmkvWithID(config.id, mode, encryptionKeyPtr, pathPtr);
+  }
 #else
   instance = MMKV::mmkvWithID(config.id, DEFAULT_MMAP_SIZE, mode, encryptionKeyPtr, pathPtr);
 #endif

--- a/package/cpp/MmkvHostObject.cpp
+++ b/package/cpp/MmkvHostObject.cpp
@@ -42,9 +42,7 @@ MmkvHostObject::MmkvHostObject(const facebook::react::MMKVConfig& config) {
           "Failed to create MMKV instance! Custom App Group directory not accessible!");
     }
     std::string groupDirStr = groupDir.UTF8String;
-
     instance = MMKV::mmkvWithID(config.id, mode, encryptionKeyPtr, &groupDirStr);
-
   } else {
     instance = MMKV::mmkvWithID(config.id, mode, encryptionKeyPtr, pathPtr);
   }


### PR DESCRIPTION
This commit adds functionality to check if an AppGroup is defined in the info.plist. If it is, the group directory is applied, allowing for shared storage between the main app and its extensions.

Closes #702 