### PR TITLE
feat: Throw errors if `set` or `recrypt` failed

### DIFF
--- a/package/.eslintrc.js
+++ b/package/.eslintrc.js
@@ -4,6 +4,5 @@ module.exports = {
   ignorePatterns: ['scripts', 'lib'],
   rules: {
     'prettier/prettier': ['warn'],
-    '@typescript-eslint/consistent-type-imports': 'warn',
   },
 };

--- a/package/src/Types.ts
+++ b/package/src/Types.ts
@@ -4,6 +4,8 @@
 export interface NativeMMKV {
   /**
    * Set a value for the given `key`.
+   *
+   * @throws an Error if the value cannot be set.
    */
   set: (key: string, value: boolean | string | number | ArrayBuffer) => void;
   /**
@@ -54,6 +56,8 @@ export interface NativeMMKV {
    * To remove encryption, pass `undefined` as a key.
    *
    * Encryption keys can have a maximum length of 16 bytes.
+   *
+   * @throws an Error if the instance cannot be recrypted.
    */
   recrypt: (key: string | undefined) => void;
   /**


### PR DESCRIPTION
With this change, MMKV now checks return values of `set(...)` or `recrypt(...)` and throws an error if these methods failed.

- Fixes https://github.com/mrousavy/react-native-mmkv/issues/583