### PR TITLE
Reduce log overhead when logging disabled

### DIFF
--- a/package/android/src/main/cpp/AndroidLogger.cpp
+++ b/package/android/src/main/cpp/AndroidLogger.cpp
@@ -8,9 +8,9 @@
 #include "MmkvLogger.h"
 #include <android/log.h>
 
-void MmkvLogger::log(const std::string& tag, const std::string& message) {
+void MmkvLogger::log(const std::string& tag, const std::string& formatString, Args... args) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wformat-security"
-  __android_log_print(ANDROID_LOG_INFO, tag.c_str(), message.c_str());
+  __android_log_print(ANDROID_LOG_INFO, tag.c_str(), formatString.c_str(), args);
 #pragma clang diagnostic pop
 }

--- a/package/cpp/MmkvLogger.h
+++ b/package/cpp/MmkvLogger.h
@@ -11,25 +11,12 @@ class MmkvLogger {
 private:
   MmkvLogger() = delete;
 
-private:
-  template <typename... Args>
-  static std::string string_format(const std::string& format, Args... args) {
-    int size_s = std::snprintf(nullptr, 0, format.c_str(), args...) + 1; // Extra space for '\0'
-    if (size_s <= 0) {
-      throw std::runtime_error("Failed to format string!");
-    }
-    auto size = static_cast<size_t>(size_s);
-    std::unique_ptr<char[]> buf(new char[size]);
-    std::snprintf(buf.get(), size, format.c_str(), args...);
-    return std::string(buf.get(), buf.get() + size - 1); // We don't want the '\0' inside
-  }
 
 public:
-  static void log(const std::string& tag, const std::string& message);
+  static void log(const std::string& tag, const std::string& formatString, Args... args);
 
   template <typename... Args>
   inline static void log(const std::string& tag, const std::string& formatString, Args&&... args) {
-    std::string formattedString = string_format(formatString, std::forward<Args>(args)...);
-    log(tag, formattedString);
+    log(tag, formatString, std::forward<Args>(args)...);
   }
 };

--- a/package/cpp/MmkvLogger.h
+++ b/package/cpp/MmkvLogger.h
@@ -17,6 +17,8 @@ public:
 
   template <typename... Args>
   inline static void log(const std::string& tag, const std::string& formatString, Args&&... args) {
+#ifdef DEBUG
     log(tag, formatString, std::forward<Args>(args)...);
+#endif
   }
 };

--- a/package/ios/AppleLogger.mm
+++ b/package/ios/AppleLogger.mm
@@ -8,9 +8,11 @@
 #import "MmkvLogger.h"
 #import <Foundation/Foundation.h>
 
-void MmkvLogger::log(const std::string& tag, const std::string& message) {
+void MmkvLogger::log(const std::string& tag, const std::string& formatString, Args... args) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wformat-security"
-  NSLog(@"[%s]: %s", tag.c_str(), message.c_str());
+if (NSDebugEnabled) {
+  NSLog(@"[%s]: " + formatString.c_str(), tag.c_str(), args);
+}
 #pragma clang diagnostic pop
 }

--- a/package/ios/AppleLogger.mm
+++ b/package/ios/AppleLogger.mm
@@ -11,8 +11,8 @@
 void MmkvLogger::log(const std::string& tag, const std::string& formatString, Args... args) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wformat-security"
-if (NSDebugEnabled) {
+#ifdef DEBUG
   NSLog(@"[%s]: " + formatString.c_str(), tag.c_str(), args);
-}
+#endif
 #pragma clang diagnostic pop
 }


### PR DESCRIPTION
Avoid a string format unless logging is enabled.

Fixes #710.