### PR TITLE
fix "Identifier 'module' has already been declared" on web v3.0.2

### DIFF
--- a/package/src/NativeMmkv.ts
+++ b/package/src/NativeMmkv.ts
@@ -85,23 +85,23 @@ export interface Spec extends TurboModule {
   createMMKV(configuration: Configuration): UnsafeObject;
 }
 
-let module: Spec | null;
+let Module: Spec | null;
 
 export function getMMKVTurboModule(): Spec {
   try {
-    if (module == null) {
+    if (Module == null) {
       // 1. Load MMKV TurboModule
-      module = TurboModuleRegistry.getEnforcing<Spec>('MmkvCxx');
+      Module = TurboModuleRegistry.getEnforcing<Spec>('MmkvCxx');
 
       // 2. Get the PlatformContext TurboModule as well
       const platformContext = getMMKVPlatformContextTurboModule();
 
       // 3. Initialize it with the documents directory from platform-specific context
       const basePath = platformContext.getBaseDirectory();
-      module.initialize(basePath);
+      Module.initialize(basePath);
     }
 
-    return module;
+    return Module;
   } catch (cause) {
     // TurboModule could not be found!
     throw new ModuleNotFoundError(cause);

--- a/package/src/NativeMmkvPlatformContext.ts
+++ b/package/src/NativeMmkvPlatformContext.ts
@@ -20,15 +20,15 @@ export interface Spec extends TurboModule {
   getAppGroupDirectory(): string | undefined;
 }
 
-let module: Spec | null;
+let Module: Spec | null;
 
 export function getMMKVPlatformContextTurboModule(): Spec {
   try {
-    if (module == null) {
+    if (Module == null) {
       // 1. Get the TurboModule
-      module = TurboModuleRegistry.getEnforcing<Spec>('MmkvPlatformContext');
+      Module = TurboModuleRegistry.getEnforcing<Spec>('MmkvPlatformContext');
     }
-    return module;
+    return Module;
   } catch (e) {
     // TurboModule could not be found!
     throw new ModuleNotFoundError(e);


### PR DESCRIPTION
when using react compiler with expo, i got this error on web:
`Identifier 'module' has already been declared`
simply renaming that `module` to `Module` fixed the issue.