### PR TITLE
feat: allow codesplitting mock file

### DIFF
--- a/package/src/MMKV.ts
+++ b/package/src/MMKV.ts
@@ -1,5 +1,3 @@
-import { createMMKV } from './createMMKV';
-import { createMockMMKV } from './createMMKV.mock';
 import { isTest } from './PlatformChecker';
 import type { Configuration } from './NativeMmkv';
 import type { Listener, MMKVInterface, NativeMMKV } from './Types';
@@ -22,8 +20,8 @@ export class MMKV implements MMKVInterface {
   constructor(configuration: Configuration = { id: 'mmkv.default' }) {
     this.id = configuration.id;
     this.nativeInstance = isTest()
-      ? createMockMMKV()
-      : createMMKV(configuration);
+      ? require('./createMMKV.mock').createMockMMKV()
+      : require('./createMMKV').createMMKV(configuration);
     this.functionCache = {};
 
     addMemoryWarningListener(this);


### PR DESCRIPTION
## Description

Hey 👋 first of all, thanks for your lib Mark :)

Here's a small PR where the mock and native file module are required inline. Otherwise, if run in a test environment, it will parse the native file and crash because it's importing react-native.