### PR TITLE
fix: enable macOS and tvOS in podspec

### DIFF
--- a/package/react-native-mmkv.podspec
+++ b/package/react-native-mmkv.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => min_ios_version_supported }
+  s.platforms    = { :ios => min_ios_version_supported, :tvos => "12.0", :osx => "10.14" }
   s.source       = { :git => "https://github.com/mrousavy/react-native-mmkv.git", :tag => "#{s.version}" }
 
   s.pod_target_xcconfig = {


### PR DESCRIPTION
Yolo'd this to unblock my react-native-macos app, which I am migrating to the new architecture.

With the new architecture enabled, I tested this change for macOS by running it with [react-native-test-app](https://github.com/microsoft/react-native-test-app).

I restored the podspec to the [previous code](https://github.com/mrousavy/react-native-mmkv/commit/3d0a289a7bf2ff1d67920890b9a740a435c5d39b) that was here in the history using git blame. I did not test tvOS support against this change, but I saw that #713 was open and asked for this change as well.

What else would you like to see in this PR? Examples, tests, etc.?
Also, it is unclear to me what the min versions should be in the podspec for tvOS and macOS.






