### PR TITLE
fix: Improve support for web projects

### DIFF
--- a/package/src/MMKV.ts
+++ b/package/src/MMKV.ts
@@ -1,8 +1,12 @@
 import { createMMKV } from './createMMKV';
 import { createMockMMKV } from './createMMKV.mock';
 import { isTest } from './PlatformChecker';
-import type { Configuration } from './NativeMmkv';
-import type { Listener, MMKVInterface, NativeMMKV } from './Types';
+import type {
+  Configuration,
+  Listener,
+  MMKVInterface,
+  NativeMMKV,
+} from './Types';
 import { addMemoryWarningListener } from './MemoryWarningListener';
 
 const onValueChangedListeners = new Map<string, ((key: string) => void)[]>();

--- a/package/src/MemoryWarningListener.web.ts
+++ b/package/src/MemoryWarningListener.web.ts
@@ -1,0 +1,5 @@
+import { MMKVInterface } from './Types';
+
+export const addMemoryWarningListener = (_mmkv: MMKVInterface): void => {
+  //no-op function, there is not a web equivalent to memory warning
+};

--- a/package/src/NativeMmkv.ts
+++ b/package/src/NativeMmkv.ts
@@ -5,6 +5,11 @@ import { ModuleNotFoundError } from './ModuleNotFoundError';
 import { getMMKVPlatformContextTurboModule } from './NativeMmkvPlatformContext';
 
 /**
+ * IMPORTANT: These types are also in the Types.ts file.
+ * Due to how react-native-codegen works these are required here as the spec types can not be separated from spec.
+ * We also need the types separate to allow bypassing importing turbo module registry in web
+ */
+/**
  * Configures the mode of the MMKV instance.
  */
 export enum Mode {

--- a/package/src/Types.ts
+++ b/package/src/Types.ts
@@ -1,4 +1,78 @@
 /**
+ * IMPORTANT: Some of these types are also in the NativeMmkv.ts file.
+ * Due to how react-native-codegen works these are required here as the spec types can not be separated from spec.
+ * We also need the types separate to allow bypassing importing turbo module registry in web
+ */
+
+/**
+ * Configures the mode of the MMKV instance.
+ */
+export enum Mode {
+  /**
+   * The MMKV instance is only used from a single process (this app).
+   */
+  SINGLE_PROCESS,
+  /**
+   * The MMKV instance may be used from multiple processes, such as app clips, share extensions or background services.
+   */
+  MULTI_PROCESS,
+}
+
+/**
+ * Used for configuration of a single MMKV instance.
+ */
+export interface Configuration {
+  /**
+   * The MMKV instance's ID. If you want to use multiple instances, make sure to use different IDs!
+   *
+   * @example
+   * ```ts
+   * const userStorage = new MMKV({ id: `user-${userId}-storage` })
+   * const globalStorage = new MMKV({ id: 'global-app-storage' })
+   * ```
+   *
+   * @default 'mmkv.default'
+   */
+  id: string;
+  /**
+   * The MMKV instance's root path. By default, MMKV stores file inside `$(Documents)/mmkv/`. You can customize MMKV's root directory on MMKV initialization:
+
+   * @example
+   * ```ts
+   * const temporaryStorage = new MMKV({ path: '/tmp/' })
+   * ```
+   *
+   * @note On iOS, if an `AppGroup` is set in `Info.plist` and `path` is `undefined`, MMKV will use the `AppGroup` directory.
+   * App Groups allow you to share MMKV storage between apps, widgets and extensions within the same AppGroup bundle.
+   * For more information, see [the `Configuration` section](https://github.com/Tencent/MMKV/wiki/iOS_tutorial#configuration).
+   *
+   * @default undefined
+   */
+  path?: string;
+  /**
+   * The MMKV instance's encryption/decryption key. By default, MMKV stores all key-values in plain text on file, relying on iOS's sandbox to make sure the file is encrypted. Should you worry about information leaking, you can choose to encrypt MMKV.
+   *
+   * Encryption keys can have a maximum length of 16 bytes.
+   *
+   * @example
+   * ```ts
+   * const secureStorage = new MMKV({ encryptionKey: 'my-encryption-key!' })
+   * ```
+   *
+   * @default undefined
+   */
+  encryptionKey?: string;
+  /**
+   * Configure the processing mode for MMKV.
+   * - `SINGLE_PROCESS`: The MMKV instance is only used from a single process (this app).
+   * - `MULTI_PROCESS`: The MMKV instance may be used from multiple processes, such as app clips, share extensions or background services.
+   *
+   * @default SINGLE_PROCESS
+   */
+  mode?: Mode;
+}
+
+/**
  * Represents a single MMKV instance.
  */
 export interface NativeMMKV {

--- a/package/src/createMMKV.ts
+++ b/package/src/createMMKV.ts
@@ -1,6 +1,6 @@
 import { Platform } from 'react-native';
-import { getMMKVTurboModule, Mode, type Configuration } from './NativeMmkv';
-import type { NativeMMKV } from './Types';
+import { getMMKVTurboModule } from './NativeMmkv';
+import { type Configuration, Mode, type NativeMMKV } from './Types';
 import { getMMKVPlatformContextTurboModule } from './NativeMmkvPlatformContext';
 
 export const createMMKV = (config: Configuration): NativeMMKV => {

--- a/package/src/createMMKV.web.ts
+++ b/package/src/createMMKV.web.ts
@@ -1,6 +1,5 @@
 /* global localStorage */
-import type { Configuration } from './NativeMmkv';
-import type { NativeMMKV } from './Types';
+import type { Configuration, NativeMMKV } from './Types';
 import { createTextEncoder } from './createTextEncoder';
 
 const canUseDOM =

--- a/package/src/hooks.ts
+++ b/package/src/hooks.ts
@@ -1,6 +1,6 @@
 import { useRef, useState, useMemo, useCallback, useEffect } from 'react';
 import { MMKV } from './MMKV';
-import type { Configuration } from './NativeMmkv';
+import type { Configuration } from './Types';
 
 function isConfigurationEqual(
   left?: Configuration,

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,4 +1,4 @@
 export * from './MMKV';
 export * from './hooks';
 
-export { Mode, Configuration } from './NativeMmkv';
+export { Mode, type Configuration } from './Types';


### PR DESCRIPTION
This PR adds 1 new web entry point and updates imports for 2 copied types.  React-native-web will no longer be necessary to use this library with webpack/vite configurations.

In order to fix this I did have to duplicate the 2 type definitions in NativeMmkv.ts.  React Native Codegen requires those types be in the file with the spec definition.  In doing so accessing those types causes imports to react native.  For Now duplicate the types with notes so the project can be built to work on web and react native.

Starting with 3.x webpack required the addition of react-native-web to work.  
Webpack would throw errors even with react-native-web but those errors seemed to be ignored and everything worked as expected. 
Vite configuration will not ignore those errors even with react-native-web.  

resolves: https://github.com/mrousavy/react-native-mmkv/issues/712 and https://github.com/mrousavy/react-native-mmkv/issues/731

Testing Notes:
Besides the items listed in guidelines I use npm file link in large project with RN 75.3,  Webpack web config and latest MMKV with these changes.  Tested Ios, Android, Webpack Web App.  Made sure any of the MMKV storages were cleared so they would rebuild and update and everything was working as expected in my app.