### PR TITLE
fix: fix error in bridgeless due to nativeCallSyncHook

### DIFF
--- a/src/createMMKV.ts
+++ b/src/createMMKV.ts
@@ -46,7 +46,7 @@ export const createMMKV = (config: MMKVConfiguration): NativeMMKV => {
     }
 
     // Check if we are running on-device (JSI)
-    if (global.nativeCallSyncHook == null || MMKVModule.install == null) {
+    if (isRemoteDebuggingInChrome() || MMKVModule.install == null) {
       throw new Error(
         'Failed to create a new MMKV instance: React Native is not running on-device. MMKV can only be used when synchronous method invocations (JSI) are possible. If you are using a remote debugger (e.g. Chrome), switch to an on-device debugger (e.g. Flipper) instead.'
       );
@@ -68,3 +68,12 @@ export const createMMKV = (config: MMKVConfiguration): NativeMMKV => {
 
   return global.mmkvCreateNewInstance(config);
 };
+
+function isRemoteDebuggingInChrome () {
+  // Remote debugging in Chrome is not supported in bridgeless
+  if ('RN$Bridgeless' in global && RN$Bridgeless === true) {
+    return false
+  }
+
+  return __DEV__ && typeof global.nativeCallSyncHook === 'undefined'
+}

--- a/src/createMMKV.ts
+++ b/src/createMMKV.ts
@@ -69,11 +69,15 @@ export const createMMKV = (config: MMKVConfiguration): NativeMMKV => {
   return global.mmkvCreateNewInstance(config);
 };
 
-function isRemoteDebuggingInChrome () {
+declare global {
+  const RN$Bridgeless: boolean;
+}
+
+function isRemoteDebuggingInChrome() {
   // Remote debugging in Chrome is not supported in bridgeless
   if ('RN$Bridgeless' in global && RN$Bridgeless === true) {
-    return false
+    return false;
   }
 
-  return __DEV__ && typeof global.nativeCallSyncHook === 'undefined'
+  return __DEV__ && typeof global.nativeCallSyncHook === 'undefined';
 }


### PR DESCRIPTION
Hi,

Closes #779 

Apps running on bridgless, old arch always has `nativeCallSyncHook` as undefined making this:
https://github.com/mrousavy/react-native-mmkv/blob/6682adfbd9b0ccb35b50cc1063ca31e569cdc34b/src/createMMKV.ts#L49-L53

always throw.

Check [this](https://github.com/reactwg/react-native-new-architecture/blob/cf0ecfd99106f7ea8101035af6133e134d12dabc/docs/enable-libraries.md?plain=1#L77-L98) guide on insuring the interop layer:
### [JavaScript] `global.nativeCallSyncHook` can't be used to detect legacy "Remote Debugging in Chrome" with JSC

`global.nativeCallSyncHook === 'undefined'` is a common way to check if you're running in "Remote Debugging in Chrome" (which is not supported with Hermes, only JSC). This is often used to provide some fallback behavior for sync native functions, because they do not work in the legacy remote debugging environment. Use `"RN$Bridgeless" in global && RN$Bridgeless === true` to determine if you are running in bridgeless. Learn more in [LinusU/react-native-get-random-values#57](https://github.com/LinusU/react-native-get-random-values/pull/57).

It is generally not recommended to fork behavior based on whether bridgeless is enabled — this is an escape hatch that should be used sparingly.


<details>
<summary>Example "isRemoteDebuggingInChrome()" function</summary>

```js
function isRemoteDebuggingInChrome () {
  // Remote debugging in Chrome is not supported in bridgeless
  if ('RN$Bridgeless' in global && RN$Bridgeless === true) {
    return false
  }

  return __DEV__ && typeof global.nativeCallSyncHook === 'undefined'
}
```

</details>


⚠️ Not sure which branch to base on. Is there a 2.x.x maintenance branch?