### PR TITLE
fix: Add `readOnly` to `new(..)` types

### DIFF
--- a/package/src/Types.ts
+++ b/package/src/Types.ts
@@ -70,6 +70,12 @@ export interface Configuration {
    * @default SINGLE_PROCESS
    */
   mode?: Mode;
+  /**
+   * If `true`, the MMKV instance can only read from the storage, but not write to it.
+   * This is more efficient if you do not need to write to it.
+   * @default false
+   */
+  readOnly?: boolean;
 }
 
 /**


### PR DESCRIPTION
The `readOnly` configuration property was supported on native, but was missing from the types when calling `new MMKV(...)`. This PR adds it there.

If you don't need to write to the MMKV database, creating it in `readOnly` mode is more efficient:

```ts
const instance = new MMKV({ id: 'storage', readOnly: true })
```