### PR TITLE
fix: Append mmkv to app group default path to mimick MMKV library

### DIFF
--- a/package/src/createMMKV.ts
+++ b/package/src/createMMKV.ts
@@ -14,7 +14,8 @@ export const createMMKV = (config: Configuration): NativeMMKV => {
           getMMKVPlatformContextTurboModule().getAppGroupDirectory();
         if (appGroupDirectory != null) {
           // If we have an `AppGroup` in Info.plist, use that as a path.
-          config.path = appGroupDirectory;
+          // We append mmkv to the path to conform to the default behavior of the MMKV library.
+          config.path = appGroupDirectory + '/mmkv';
         }
       } catch (e) {
         // We cannot throw errors here because it is a sync C++ TurboModule func. idk why.


### PR DESCRIPTION
This is a proposed fix for #812.

When upgrading from v2 to v3 of the library *with an app group on iOS*, mmkv data is lost.

The data loss occurs when we pass the app group path when initializing the native MMKV instance without appending `/mmkv` to that path (in doing so, we diverge from the default behavior of the library as outlined here https://github.com/Tencent/MMKV/blob/64c3d03951dd1c784bb2eeb5561b1899f56d1155/iOS/MMKV/MMKV/MMKV.h#L56).

Not sure if this is the best way to achieve the fix (or how to test it), so suggestions/enhancements are welcome.