### PR TITLE
Correct Linking issue on RN 0.80

### DIFF
--- a/package/react-native-mmkv.podspec
+++ b/package/react-native-mmkv.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
     "GCC_PREPROCESSOR_DEFINITIONS" => "$(inherited) FORCE_POSIX",
   }
   s.compiler_flags = '-x objective-c++'
-
+  s.libraries    = "z", "c++"
   s.source_files = [
     # react-native-mmkv
     "ios/**/*.{h,m,mm}",


### PR DESCRIPTION
<img width="491" alt="image" src="https://github.com/user-attachments/assets/8a75fefb-57fe-46af-8055-7362913a89b8" />
Build fails with above error on latest RN(0.80).

This PR aims to fix that