### PR TITLE
Set C++ standard to C++20 in CMake configuration

### DIFF
--- a/package/android/CMakeLists.txt
+++ b/package/android/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.9.0)
 project(ReactNativeMmkv)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 # Compile sources
 add_library(


### PR DESCRIPTION
<img width="1058" height="189" alt="image" src="https://github.com/user-attachments/assets/b803ba62-7ff8-4373-8d39-2e2b9fff9932" />


I am facing this issue in latest RN(0.81-rc0). As per error RN uses` requires` which is a c++ 20 feature. So build is failing.