### PR TITLE
Fix Expo plugin for android

### DIFF
--- a/packages/react-native-mmkv/app.plugin.js
+++ b/packages/react-native-mmkv/app.plugin.js
@@ -1,1 +1,1 @@
-module.exports = require('./lib/commonjs/expo-plugin/withMMKV')
+module.exports = require('./lib/expo-plugin/withMMKV')

--- a/packages/react-native-mmkv/app.plugin.js
+++ b/packages/react-native-mmkv/app.plugin.js
@@ -1,1 +1,1 @@
-module.exports = require('./lib/expo-plugin/withMMKV')
+module.exports = require('./lib/expo-plugin/withMMKV.cjs')

--- a/packages/react-native-mmkv/src/expo-plugin/withMMKV.cts
+++ b/packages/react-native-mmkv/src/expo-plugin/withMMKV.cts
@@ -1,11 +1,12 @@
-import type { ConfigPlugin } from '@expo/config-plugins'
-import { createRunOncePlugin, withGradleProperties } from '@expo/config-plugins'
+import type { ConfigPlugin, ExportedConfigWithProps } from '@expo/config-plugins'
+const { createRunOncePlugin, withGradleProperties } = require('@expo/config-plugins')
+import type { Properties } from '@expo/config-plugins/build/android'
 
 const pkg = require('../../package.json')
 
 const withMMKV: ConfigPlugin<{}> = (config) => {
   // remove 32-bit architectures from gradle.properties
-  return withGradleProperties(config, (cfg) => {
+  return withGradleProperties(config, (cfg: ExportedConfigWithProps<Properties.PropertiesItem[]>) => {
     // Define the wanted property
     const property = {
       type: 'property',
@@ -27,4 +28,4 @@ const withMMKV: ConfigPlugin<{}> = (config) => {
   })
 }
 
-export default createRunOncePlugin(withMMKV, pkg.name, pkg.version)
+export = createRunOncePlugin(withMMKV, pkg.name, pkg.version) as ConfigPlugin<{}>

--- a/packages/react-native-mmkv/src/expo-plugin/withMMKV.ts
+++ b/packages/react-native-mmkv/src/expo-plugin/withMMKV.ts
@@ -6,16 +6,23 @@ const pkg = require('../../package.json')
 const withMMKV: ConfigPlugin<{}> = (config) => {
   // remove 32-bit architectures from gradle.properties
   return withGradleProperties(config, (cfg) => {
-    // Drop any existing entry…
-    cfg.modResults = cfg.modResults.filter(
-      (p) => !(p.type === 'property' && p.key === 'reactNativeArchitectures')
-    )
-    // …and force 64-bit only.
-    cfg.modResults.push({
+    // Define the wanted property
+    const property = {
       type: 'property',
       key: 'reactNativeArchitectures',
       value: 'arm64-v8a,x86_64',
-    })
+    } as const
+    // If it exists, update its value
+    const index = cfg.modResults.findIndex(
+      (p) => p.type === 'property' && p.key === property.key
+    )
+    if (index !== -1) {
+      cfg.modResults[index] = property
+    }
+    // Else add it to the properties
+    else {
+      cfg.modResults.push(property)
+    }
     return cfg
   })
 }


### PR DESCRIPTION
This PR fixes the Expo config plugin so that it generates the correct `gradle.properties`.

Included changes:
- Fixed the path in `app.plugin.js` to the correct plugin entry file
- Refactored the plugin to commonJS (with .cts extension) to avoid a bug with VSCode not recognising the plugin correctly in app.json
- Updated the property in-place instead of nuking the key and pushing a new one at the end of the file. This way, the generated file has the property next to its comment, like so:

```
# Use this property to specify which architecture you want to build.
# You can also override it from the CLI using
# ./gradlew <task> -PreactNativeArchitectures=x86_64
reactNativeArchitectures=arm64-v8a,x86_64
```

The generated `gradle.properties` is now correct, but it does not fix the Android build in an expo project. This seems to be a separate issue.