### PR TITLE
chore: update package description to be more meaningful

### DIFF
--- a/packages/react-native-mmkv/package.json
+++ b/packages/react-native-mmkv/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-mmkv",
   "version": "4.0.0-beta.9",
-  "description": "react-native-mmkv",
+  "description": "⚡️ The fastest key/value storage for React Native.",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
# Why

When validating data in React Native Directory, I have spotted that `react-native-mmkv` uses the package name as a package description:

<img width="2420" height="450" alt="Screenshot 2025-09-18 at 10 06 05" src="https://github.com/user-attachments/assets/5abfc913-09a3-4f07-a122-8e22f337afed" />

# How

Update package description to be more meaningful (copied over first sentence from the GitHub repository description), which should help the RND viewers and [improve discoverability](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#description-1) in npm registry.