### PR TITLE
feat: Update MMKVCore to 2.2.4 which defines Modules

### DIFF
--- a/docs/V4_UPGRADE_GUIDE.md
+++ b/docs/V4_UPGRADE_GUIDE.md
@@ -66,8 +66,10 @@ Command `pod install` failed.
 The Swift pod `NitroMmkv` depends upon `MMKVCore`, which does not define modules. To opt into those targets generating module maps (which is necessary to import them from Swift when building as static libraries), you may set `use_modular_headers!` globally in your Podfile, or specify `:modular_headers => true` for particular dependencies.
 ```
 
-..you need to upgrade `MMKVCore` to a version that includes [this PR](https://github.com/Tencent/MMKV/pull/1579) (v2.2.4 or higher), or add this to your `Podfile`:
+..you are likely on an old version of `MMKVCore`. Make sure to update to a version that includes [this PR](https://github.com/Tencent/MMKV/pull/1579) (v2.2.4 or higher), or add this to your `Podfile`:
 
 ```rb
 pod 'MMKVCore', :modular_headers => true
 ```
+
+If you are on the latest react-native-mmkv V4 version, it should include a working `MMKVCore` by default - so you shouldn't see this error unless you manually added a dependency on `MMKVCore`/`MMKV` to your `Podfile`.

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -23,8 +23,6 @@ target 'MmkvExample' do
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod 'MMKVCore', :modular_headers => true
-
   post_install do |installer|
     # https://github.com/facebook/react-native/blob/main/packages/react-native/scripts/react_native_pods.rb#L197-L202
     react_native_post_install(

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.81.0):
     - hermes-engine/Pre-built (= 0.81.0)
   - hermes-engine/Pre-built (0.81.0)
-  - MMKVCore (2.2.3)
+  - MMKVCore (2.2.4)
   - NitroMmkv (4.0.0-beta.11):
     - boost
     - DoubleConversion
@@ -16,7 +16,7 @@ PODS:
     - fmt
     - glog
     - hermes-engine
-    - MMKVCore (>= 2.2.3)
+    - MMKVCore (= 2.2.4)
     - NitroModules
     - RCT-Folly
     - RCT-Folly/Fabric
@@ -2382,7 +2382,6 @@ DEPENDENCIES:
   - fmt (from `../../node_modules/react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
-  - MMKVCore
   - NitroMmkv (from `../../node_modules/react-native-mmkv`)
   - NitroModules (from `../../node_modules/react-native-nitro-modules`)
   - RCT-Folly (from `../../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
@@ -2617,8 +2616,8 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: e7491a2038f2618c8cd444ed411a6deb350a3742
-  MMKVCore: 6d5cc1bacce539f4c974985dfe646fb65a5d27d2
-  NitroMmkv: 7ccbeac687d92f99de7a8474d922e5db05baac76
+  MMKVCore: f2dd4c9befea04277a55e84e7812f930537993df
+  NitroMmkv: 7ddcd26aba1ac54a778edc6536abb83f5704ce0a
   NitroModules: df9af25a70fccb693fa5799026d8162f579007ae
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: 0735ab4f6b3ec93a7f98187b5da74d7916e2cf4c
@@ -2687,6 +2686,6 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: b01392348aeea02064c21a2762a42893d82b60a7
 
-PODFILE CHECKSUM: 941570c81374ba376a082a6ecec1f5251bfbe088
+PODFILE CHECKSUM: ac6e3a3935879b4d187353a98679212e0e3604ce
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/packages/react-native-mmkv/NitroMmkv.podspec
+++ b/packages/react-native-mmkv/NitroMmkv.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   # Add MMKV Core dependency
   s.compiler_flags = '-x objective-c++'
   s.libraries    = 'z', 'c++'
-  s.dependency 'MMKVCore', '>= 2.2.3'
+  s.dependency 'MMKVCore', '2.2.4'
 
   # TODO: Remove when no one uses RN 0.79 anymore
   # Add support for React Native 0.79 or below


### PR DESCRIPTION
Updates MMKVCore to [v2.2.4](https://github.com/Tencent/MMKV/releases/tag/v2.2.4), which now includes my PR to define modules. This now removes the need from users to add it to their `Podfile`s, and was the last change needed to make V4 beta stable.
