### PR TITLE
chore: move postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "example"
   ],
   "scripts": {
+    "postinstall": "tsc || exit 0;",
     "build": "bun mmkv build",
     "bootstrap": "bun i && bun run build && cd example && bundle install && bun pods",
     "typecheck": "bun --filter=\"**\" typecheck",

--- a/packages/react-native-mmkv/package.json
+++ b/packages/react-native-mmkv/package.json
@@ -31,7 +31,6 @@
     "README.md"
   ],
   "scripts": {
-    "postinstall": "tsc || exit 0;",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf android/build node_modules/**/android/build lib",
     "lint": "eslint \"**/*.{js,ts,tsx}\" --fix",


### PR DESCRIPTION
Fixes #938 

This PR moves the postinstall script from `package.json` in `react-native-mmkv` to root project.