### PR TITLE
feat: Add `MMKV.config` getter

### DIFF
--- a/packages/react-native-mmkv/cpp/HybridMMKV.hpp
+++ b/packages/react-native-mmkv/cpp/HybridMMKV.hpp
@@ -19,6 +19,7 @@ public:
 
 public:
   // Properties
+  Configuration getConfig() override;
   double getSize() override;
   bool getIsReadOnly() override;
 
@@ -41,7 +42,8 @@ private:
   static MMKVMode getMMKVMode(const Configuration& config);
 
 private:
-  MMKV* instance;
+  MMKV* _instance;
+  Configuration _config;
 };
 
 } // namespace margelo::nitro::mmkv

--- a/packages/react-native-mmkv/nitrogen/generated/shared/c++/HybridMMKVSpec.cpp
+++ b/packages/react-native-mmkv/nitrogen/generated/shared/c++/HybridMMKVSpec.cpp
@@ -14,6 +14,7 @@ namespace margelo::nitro::mmkv {
     HybridObject::loadHybridMethods();
     // load custom methods/properties
     registerHybrids(this, [](Prototype& prototype) {
+      prototype.registerHybridGetter("config", &HybridMMKVSpec::getConfig);
       prototype.registerHybridGetter("size", &HybridMMKVSpec::getSize);
       prototype.registerHybridGetter("isReadOnly", &HybridMMKVSpec::getIsReadOnly);
       prototype.registerHybridMethod("set", &HybridMMKVSpec::set);

--- a/packages/react-native-mmkv/nitrogen/generated/shared/c++/HybridMMKVSpec.hpp
+++ b/packages/react-native-mmkv/nitrogen/generated/shared/c++/HybridMMKVSpec.hpp
@@ -13,9 +13,12 @@
 #error NitroModules cannot be found! Are you sure you installed NitroModules properly?
 #endif
 
+// Forward declaration of `Configuration` to properly resolve imports.
+namespace margelo::nitro::mmkv { struct Configuration; }
 // Forward declaration of `Listener` to properly resolve imports.
 namespace margelo::nitro::mmkv { struct Listener; }
 
+#include "Configuration.hpp"
 #include <string>
 #include <NitroModules/ArrayBuffer.hpp>
 #include <variant>
@@ -51,6 +54,7 @@ namespace margelo::nitro::mmkv {
 
     public:
       // Properties
+      virtual Configuration getConfig() = 0;
       virtual double getSize() = 0;
       virtual bool getIsReadOnly() = 0;
 

--- a/packages/react-native-mmkv/src/createMMKV/createMMKV.ts
+++ b/packages/react-native-mmkv/src/createMMKV/createMMKV.ts
@@ -13,7 +13,7 @@ let platformContext: MMKVPlatformContext | undefined
 export function createMMKV(configuration?: Configuration): MMKV {
   if (isTest()) {
     // In a test environment, we mock the MMKV instance.
-    return createMockMMKV()
+    return createMockMMKV(configuration)
   }
 
   if (platformContext == null) {

--- a/packages/react-native-mmkv/src/createMMKV/createMMKV.web.ts
+++ b/packages/react-native-mmkv/src/createMMKV/createMMKV.web.ts
@@ -85,6 +85,7 @@ export function createMMKV(
   }
 
   return {
+    config: config,
     clearAll: () => {
       const keys = Object.keys(storage())
       for (const key of keys) {

--- a/packages/react-native-mmkv/src/createMMKV/createMockMMKV.ts
+++ b/packages/react-native-mmkv/src/createMMKV/createMockMMKV.ts
@@ -1,9 +1,13 @@
 import type { MMKV } from '../specs/MMKV.nitro'
+import type { Configuration } from '../specs/MMKVFactory.nitro'
 
 /**
  * Mock MMKV instance when used in a Jest/Test environment.
  */
-export function createMockMMKV(): MMKV {
+export function createMockMMKV(
+  configuration: Configuration = { id: 'mmkv.default' }
+): MMKV {
+  const config = configuration
   const storage = new Map<string, string | boolean | number | ArrayBuffer>()
   const listeners = new Set<(key: string) => void>()
 
@@ -14,6 +18,7 @@ export function createMockMMKV(): MMKV {
   }
 
   return {
+    config: config,
     clearAll: () => {
       const keysBefore = storage.keys()
       storage.clear()

--- a/packages/react-native-mmkv/src/specs/MMKV.nitro.ts
+++ b/packages/react-native-mmkv/src/specs/MMKV.nitro.ts
@@ -1,10 +1,25 @@
 import type { HybridObject } from 'react-native-nitro-modules'
+import type { Configuration } from './MMKVFactory.nitro'
 
 export interface Listener {
   remove: () => void
 }
 
 export interface MMKV extends HybridObject<{ ios: 'c++'; android: 'c++' }> {
+  /**
+   * The {@linkcode Configuration} that was used to create this {@linkcode MMKV}
+   * instance.
+   */
+  readonly config: Configuration
+  /**
+   * Get the current total size of the storage, in bytes.
+   */
+  readonly size: number
+  /**
+   * Returns whether this instance is in read-only mode or not.
+   * If this is `true`, you can only use "get"-functions.
+   */
+  readonly isReadOnly: boolean
   /**
    * Set a {@linkcode value} for the given {@linkcode key}.
    *
@@ -75,15 +90,6 @@ export interface MMKV extends HybridObject<{ ios: 'c++'; android: 'c++' }> {
    * In most applications, this is not needed at all.
    */
   trim(): void
-  /**
-   * Get the current total size of the storage, in bytes.
-   */
-  readonly size: number
-  /**
-   * Returns whether this instance is in read-only mode or not.
-   * If this is `true`, you can only use "get"-functions.
-   */
-  readonly isReadOnly: boolean
   /**
    * Adds a value changed listener. The Listener will be called whenever any value
    * in this storage instance changes (set or delete).


### PR DESCRIPTION
Adds `MMKV.config` to get the original config used to create this MMKV instance.

```ts
const storage = createMMKV({ id: 'custom' })
const id = storage.config.id // <-- custom
```

- Resolves https://github.com/mrousavy/react-native-mmkv/issues/941