### PR TITLE
Mention mmkv being an in-memory store

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 <br/>
 
 
-* **MMKV** is an efficient, small, in-memory synced with files (backed by mmap) mobile key-value storage framework developed by WeChat. See [Tencent/MMKV](https://github.com/Tencent/MMKV) for more information
+* **MMKV** is an efficient, small, **in-memory** mobile key-value storage framework developed by WeChat. Data is stored using `mmap` which syncs it with files for persistence. See [Tencent/MMKV](https://github.com/Tencent/MMKV) for more information
 * **react-native-mmkv** is a library that allows you to easily use **MMKV** inside your React Native app through fast and direct JS bindings to the native C++ library.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 <br/>
 
 
-* **MMKV** is an efficient, small mobile key-value storage framework developed by WeChat. See [Tencent/MMKV](https://github.com/Tencent/MMKV) for more information
+* **MMKV** is an efficient, small, in-memory synced with files (backed by mmap) mobile key-value storage framework developed by WeChat. See [Tencent/MMKV](https://github.com/Tencent/MMKV) for more information
 * **react-native-mmkv** is a library that allows you to easily use **MMKV** inside your React Native app through fast and direct JS bindings to the native C++ library.
 
 ## Features


### PR DESCRIPTION
Adds additional information about MMKV being an in-memory store backed by `mmap` to avoid confusion. This gives more context for people that do not know what `mmap` or `MMKV` are or how they work.
I, personally, made the mistake of persisting tanstack query's cache with `maxAge: Infinity` to `react-native-mmkv`, without ever realizing that it is an in-memory store and that I am filling the RAM of my users' devices.