### PR TITLE
Remove z and c++ libraries from podspec

### DIFF
--- a/packages/react-native-mmkv/NitroMmkv.podspec
+++ b/packages/react-native-mmkv/NitroMmkv.podspec
@@ -24,7 +24,6 @@ Pod::Spec.new do |s|
 
   # Add MMKV Core dependency
   s.compiler_flags = '-x objective-c++'
-  s.libraries    = 'z', 'c++'
   s.dependency 'MMKVCore', '2.2.4'
 
   # TODO: Remove when no one uses RN 0.79 anymore


### PR DESCRIPTION
This is not needed since we dont build it from source anymore. In Most cases it will be removed automatically though