### PR TITLE
Update Tinybase MMKV documentation link

### DIFF
--- a/docs/WRAPPER_TINYBASE.md
+++ b/docs/WRAPPER_TINYBASE.md
@@ -1,6 +1,6 @@
 #  tinybase wrapper
 
-If you want to use MMKV with [Tinybase](https://github.com/pmndrs/zustand#persist-middleware), follow these steps:
+If you want to use MMKV with [Tinybase](https://tinybase.org/api/persister-react-native-mmkv), follow these steps:
 
 ```ts
 import { createMMKV } from 'react-native-mmkv'


### PR DESCRIPTION
Update the link from `https://github.com/pmndrs/zustand#persist-middleware` to `https://tinybase.org/api/persister-react-native-mmkv`