### PR TITLE
feat: Add `importAllFrom(...)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,17 @@ if (size >= 4096) {
 }
 ```
 
+### Importing all data from another MMKV instance
+
+To import all keys and values from another MMKV instance, use `importAllFrom(...)`:
+
+```ts
+const storage = createMMKV(...)
+const otherStorage = createMMKV(...)
+
+const importedCount = storage.importAllFrom(otherStorage)
+```
+
 ### Check if an MMKV instance exists
 
 To check if an MMKV instance exists, use `existsMMKV(...)`:

--- a/example/__tests__/MMKV.harness.ts
+++ b/example/__tests__/MMKV.harness.ts
@@ -399,6 +399,32 @@ describe('MMKV Configuration & Multiple Instances', () => {
       instances.forEach(instance => instance.clearAll());
     });
 
+    it('should import other keys properly', () => {
+      const storage1 = createMMKV({ id: 'first-storage' })
+      const storage2 = createMMKV({ id: 'second-storage' })
+      storage1.clearAll()
+      storage2.clearAll()
+
+      expect(storage1.getAllKeys()).toEqual([])
+      expect(storage2.getAllKeys()).toEqual([])
+
+      storage1.set('key1', 'value1')
+      storage1.set('key2', 42)
+      storage1.set('key3', true)
+
+      expect(storage1.getAllKeys().length).toStrictEqual(3)
+      expect(storage2.getAllKeys().length).toStrictEqual(0)
+
+      storage2.importAllFrom(storage1)
+
+      expect(storage1.getAllKeys().length).toStrictEqual(3)
+      expect(storage2.getAllKeys().length).toStrictEqual(3)
+
+      expect(storage2.getString('key1')).toStrictEqual('value1')
+      expect(storage2.getNumber('key2')).toStrictEqual(42)
+      expect(storage2.getBoolean('key3')).toStrictEqual(true)
+    })
+
     it('should handle instance properties correctly', () => {
       const storage = createMMKV({ id: 'properties-test' });
 
@@ -810,6 +836,11 @@ describe('MMKV Listeners & Observers', () => {
 });
 
 describe('Deleting instances and checking if they exist', () => {
+  beforeEach(() => {
+    deleteMMKV('some-instance')
+    deleteMMKV('some-non-existing-instance')
+  })
+
   describe('Checking if an instance exists', () => {
     it('should exist', () => {
       createMMKV({ id: 'some-instance' })

--- a/packages/react-native-mmkv/cpp/HybridMMKV.cpp
+++ b/packages/react-native-mmkv/cpp/HybridMMKV.cpp
@@ -212,4 +212,14 @@ MMKVMode HybridMMKV::getMMKVMode(const Configuration& config) {
   }
 }
 
+double HybridMMKV::importAllFrom(const std::shared_ptr<HybridMMKVSpec>& other) {
+  auto hybridMMKV = std::dynamic_pointer_cast<HybridMMKV>(other);
+  if (hybridMMKV == nullptr) {
+    throw std::runtime_error("The given `MMKV` instance is not of type `HybridMMKV`!");
+  }
+
+  size_t importedCount = instance->importFrom(hybridMMKV->instance);
+  return static_cast<double>(importedCount);
+}
+
 } // namespace margelo::nitro::mmkv

--- a/packages/react-native-mmkv/cpp/HybridMMKV.hpp
+++ b/packages/react-native-mmkv/cpp/HybridMMKV.hpp
@@ -37,6 +37,7 @@ public:
   void recrypt(const std::optional<std::string>& key) override;
   void trim() override;
   Listener addOnValueChangedListener(const std::function<void(const std::string& /* key */)>& onValueChanged) override;
+  double importAllFrom(const std::shared_ptr<HybridMMKVSpec>& other) override;
 
 private:
   static MMKVMode getMMKVMode(const Configuration& config);

--- a/packages/react-native-mmkv/nitrogen/generated/shared/c++/HybridMMKVSpec.cpp
+++ b/packages/react-native-mmkv/nitrogen/generated/shared/c++/HybridMMKVSpec.cpp
@@ -29,6 +29,7 @@ namespace margelo::nitro::mmkv {
       prototype.registerHybridMethod("recrypt", &HybridMMKVSpec::recrypt);
       prototype.registerHybridMethod("trim", &HybridMMKVSpec::trim);
       prototype.registerHybridMethod("addOnValueChangedListener", &HybridMMKVSpec::addOnValueChangedListener);
+      prototype.registerHybridMethod("importAllFrom", &HybridMMKVSpec::importAllFrom);
     });
   }
 

--- a/packages/react-native-mmkv/nitrogen/generated/shared/c++/HybridMMKVSpec.hpp
+++ b/packages/react-native-mmkv/nitrogen/generated/shared/c++/HybridMMKVSpec.hpp
@@ -15,6 +15,8 @@
 
 // Forward declaration of `Listener` to properly resolve imports.
 namespace margelo::nitro::mmkv { struct Listener; }
+// Forward declaration of `HybridMMKVSpec` to properly resolve imports.
+namespace margelo::nitro::mmkv { class HybridMMKVSpec; }
 
 #include <string>
 #include <NitroModules/ArrayBuffer.hpp>
@@ -23,6 +25,8 @@ namespace margelo::nitro::mmkv { struct Listener; }
 #include <vector>
 #include "Listener.hpp"
 #include <functional>
+#include <memory>
+#include "HybridMMKVSpec.hpp"
 
 namespace margelo::nitro::mmkv {
 
@@ -69,6 +73,7 @@ namespace margelo::nitro::mmkv {
       virtual void recrypt(const std::optional<std::string>& key) = 0;
       virtual void trim() = 0;
       virtual Listener addOnValueChangedListener(const std::function<void(const std::string& /* key */)>& onValueChanged) = 0;
+      virtual double importAllFrom(const std::shared_ptr<HybridMMKVSpec>& other) = 0;
 
     protected:
       // Hybrid Setup

--- a/packages/react-native-mmkv/src/createMMKV/createMMKV.web.ts
+++ b/packages/react-native-mmkv/src/createMMKV/createMMKV.web.ts
@@ -114,5 +114,18 @@ export function createMMKV(
         },
       }
     },
+    importAllFrom: (other) => {
+      const storage = getLocalStorage()
+      const keys = other.getAllKeys()
+      let imported = 0
+      for (const key of keys) {
+        const string = other.getString(key)
+        if (string != null) {
+          storage.set(key, string)
+          imported++
+        }
+      }
+      return imported
+    },
   }
 }

--- a/packages/react-native-mmkv/src/createMMKV/createMockMMKV.ts
+++ b/packages/react-native-mmkv/src/createMMKV/createMockMMKV.ts
@@ -79,5 +79,17 @@ export function createMockMMKV(
         },
       }
     },
+    importAllFrom: (other) => {
+      const keys = other.getAllKeys()
+      let imported = 0
+      for (const key of keys) {
+        const data = other.getBuffer(key)
+        if (data != null) {
+          storage.set(key, data)
+          imported++
+        }
+      }
+      return imported
+    },
   }
 }

--- a/packages/react-native-mmkv/src/specs/MMKV.nitro.ts
+++ b/packages/react-native-mmkv/src/specs/MMKV.nitro.ts
@@ -95,4 +95,11 @@ export interface MMKV extends HybridObject<{ ios: 'c++'; android: 'c++' }> {
    * To unsubscribe from value changes, call `remove()` on the Listener.
    */
   addOnValueChangedListener(onValueChanged: (key: string) => void): Listener
+
+  /**
+   * Imports all keys and values from the
+   * given other {@linkcode MMKV} instance.
+   * @returns the number of imported keys/values.
+   */
+  importAllFrom(other: MMKV): number
 }


### PR DESCRIPTION
Adds `importAllFrom(...)` to `MMKV` which allows importing all keys/values from another instance.
It returns the number of imported items.

This is a follow-up PR of https://github.com/mrousavy/react-native-mmkv/pull/968 to fix https://github.com/mrousavy/react-native-mmkv/issues/967.

This also adds harness tests for it.