### PR TITLE
chore: Add encrypted storage persistance tests

### DIFF
--- a/example/__tests__/MMKV.harness.ts
+++ b/example/__tests__/MMKV.harness.ts
@@ -549,6 +549,16 @@ describe('MMKV Encryption & Security', () => {
         expect(storage.getString('test')).toStrictEqual('value');
       }
     });
+
+    it('should handle long encryption keys', () => {
+      const storage = createMMKV({
+        id: 'some-long-encrypted-instance',
+        encryptionKey: 'some LONG encryption key with emojis 😆😍',
+      });
+
+      storage.set('test', 'value');
+      expect(storage.getString('test')).toStrictEqual('value');
+    });
   });
 });
 


### PR DESCRIPTION
Adds a test that confirms an encrypted MMKV instance persists it's data even after closing and re-opening the same instance