### PR TITLE
feat: Add `.length` (key length vs `byteSize`)

### DIFF
--- a/example/__tests__/MMKV.harness.ts
+++ b/example/__tests__/MMKV.harness.ts
@@ -435,9 +435,9 @@ describe('MMKV Configuration & Multiple Instances', () => {
       storage.set('key1', 'value1');
       storage.set('key2', 42);
 
+      expect(typeof storage.length).toBe('number');
+      expect(storage.length).toStrictEqual(2);
       expect(storage.getAllKeys().length).toStrictEqual(2);
-      expect(typeof storage.size).toBe('number');
-      expect(storage.size).toBeGreaterThan(0);
 
       // Clean up
       storage.clearAll();
@@ -622,16 +622,28 @@ describe('MMKV Storage Management', () => {
   });
 
   describe('Storage Size & Management', () => {
-    it('should track storage size correctly', () => {
-      const initialSize = storage.size;
+    it('should track storage byte size correctly', () => {
+      const initialSize = storage.byteSize;
 
       storage.set('test-key', 'test-value');
-      expect(storage.size).toBeGreaterThan(initialSize);
+      expect(storage.byteSize).toBeGreaterThan(initialSize);
 
-      const sizeAfterSet = storage.size;
+      const sizeAfterSet = storage.byteSize;
 
       storage.set('another-key', 'another-value');
-      expect(storage.size).toBeGreaterThan(sizeAfterSet);
+      expect(storage.byteSize).toBeGreaterThan(sizeAfterSet);
+    });
+
+    it('should track storage key length correctly', () => {
+      const initialLength = storage.length;
+
+      storage.set('test-key', 'test-value');
+      expect(storage.length).toStrictEqual(initialLength + 1);
+
+      const lengthAfterSet = storage.length;
+
+      storage.set('another-key', 'another-value');
+      expect(storage.length).toBeGreaterThan(lengthAfterSet);
     });
 
     it('should handle trim operation', () => {
@@ -640,7 +652,7 @@ describe('MMKV Storage Management', () => {
         storage.set(`key-${i}`, `value-${i}`);
       }
 
-      const sizeBeforeTrim = storage.size;
+      const sizeBeforeTrim = storage.byteSize;
       expect(sizeBeforeTrim).toBeGreaterThan(0);
 
       // Remove half the data
@@ -665,7 +677,8 @@ describe('MMKV Storage Management', () => {
       storage.set('buffer-key', new Uint8Array([1, 2, 3]).buffer);
 
       expect(storage.getAllKeys().length).toStrictEqual(4);
-      expect(storage.size).toBeGreaterThan(0);
+      expect(storage.byteSize).toBeGreaterThan(0);
+      expect(storage.length).toBeGreaterThan(0);
 
       storage.clearAll();
 
@@ -674,6 +687,7 @@ describe('MMKV Storage Management', () => {
       expect(storage.contains('number-key')).toBe(false);
       expect(storage.contains('boolean-key')).toBe(false);
       expect(storage.contains('buffer-key')).toBe(false);
+      expect(storage.length).toBe(0)
     });
 
     it('should handle storage operations after clearAll', () => {

--- a/packages/react-native-mmkv/cpp/HybridMMKV.cpp
+++ b/packages/react-native-mmkv/cpp/HybridMMKV.cpp
@@ -68,9 +68,19 @@ HybridMMKV::HybridMMKV(const Configuration& config) : HybridObject(TAG) {
 std::string HybridMMKV::getId() {
   return instance->mmapID();
 }
+
+double HybridMMKV::getLength() {
+  return instance->count();
+}
+
 double HybridMMKV::getSize() {
+  return getByteSize();
+}
+
+double HybridMMKV::getByteSize() {
   return instance->actualSize();
 }
+
 bool HybridMMKV::getIsReadOnly() {
   return instance->isReadOnly();
 }
@@ -118,6 +128,7 @@ void HybridMMKV::set(const std::string& key, const std::variant<bool, std::share
   // Notify on changed
   MMKVValueChangedListenerRegistry::notifyOnValueChanged(instance->mmapID(), key);
 }
+
 std::optional<bool> HybridMMKV::getBoolean(const std::string& key) {
   bool hasValue;
   bool result = instance->getBool(key, /* defaultValue */ false, &hasValue);
@@ -127,6 +138,7 @@ std::optional<bool> HybridMMKV::getBoolean(const std::string& key) {
     return std::nullopt;
   }
 }
+
 std::optional<std::string> HybridMMKV::getString(const std::string& key) {
   std::string result;
   bool hasValue = instance->getString(key, result, /* inplaceModification */ true);
@@ -136,6 +148,7 @@ std::optional<std::string> HybridMMKV::getString(const std::string& key) {
     return std::nullopt;
   }
 }
+
 std::optional<double> HybridMMKV::getNumber(const std::string& key) {
   bool hasValue;
   double result = instance->getDouble(key, /* defaultValue */ 0.0, &hasValue);
@@ -145,6 +158,7 @@ std::optional<double> HybridMMKV::getNumber(const std::string& key) {
     return std::nullopt;
   }
 }
+
 std::optional<std::shared_ptr<ArrayBuffer>> HybridMMKV::getBuffer(const std::string& key) {
   MMBuffer result;
 #ifdef __APPLE__
@@ -161,9 +175,11 @@ std::optional<std::shared_ptr<ArrayBuffer>> HybridMMKV::getBuffer(const std::str
     return std::nullopt;
   }
 }
+
 bool HybridMMKV::contains(const std::string& key) {
   return instance->containsKey(key);
 }
+
 bool HybridMMKV::remove(const std::string& key) {
   bool wasRemoved = instance->removeValueForKey(key);
   if (wasRemoved) {
@@ -172,9 +188,11 @@ bool HybridMMKV::remove(const std::string& key) {
   }
   return wasRemoved;
 }
+
 std::vector<std::string> HybridMMKV::getAllKeys() {
   return instance->allKeys();
 }
+
 void HybridMMKV::clearAll() {
   auto keysBefore = getAllKeys();
   instance->clearAll();

--- a/packages/react-native-mmkv/cpp/HybridMMKV.hpp
+++ b/packages/react-native-mmkv/cpp/HybridMMKV.hpp
@@ -21,6 +21,8 @@ public:
   // Properties
   std::string getId() override;
   double getSize() override;
+  double getByteSize() override;
+  double getLength() override;
   bool getIsReadOnly() override;
   bool getIsEncrypted() override;
 

--- a/packages/react-native-mmkv/nitrogen/generated/shared/c++/HybridMMKVSpec.cpp
+++ b/packages/react-native-mmkv/nitrogen/generated/shared/c++/HybridMMKVSpec.cpp
@@ -15,7 +15,9 @@ namespace margelo::nitro::mmkv {
     // load custom methods/properties
     registerHybrids(this, [](Prototype& prototype) {
       prototype.registerHybridGetter("id", &HybridMMKVSpec::getId);
+      prototype.registerHybridGetter("length", &HybridMMKVSpec::getLength);
       prototype.registerHybridGetter("size", &HybridMMKVSpec::getSize);
+      prototype.registerHybridGetter("byteSize", &HybridMMKVSpec::getByteSize);
       prototype.registerHybridGetter("isReadOnly", &HybridMMKVSpec::getIsReadOnly);
       prototype.registerHybridGetter("isEncrypted", &HybridMMKVSpec::getIsEncrypted);
       prototype.registerHybridMethod("set", &HybridMMKVSpec::set);

--- a/packages/react-native-mmkv/nitrogen/generated/shared/c++/HybridMMKVSpec.hpp
+++ b/packages/react-native-mmkv/nitrogen/generated/shared/c++/HybridMMKVSpec.hpp
@@ -59,7 +59,9 @@ namespace margelo::nitro::mmkv {
     public:
       // Properties
       virtual std::string getId() = 0;
+      virtual double getLength() = 0;
       virtual double getSize() = 0;
+      virtual double getByteSize() = 0;
       virtual bool getIsReadOnly() = 0;
       virtual bool getIsEncrypted() = 0;
 

--- a/packages/react-native-mmkv/src/createMMKV/createMMKV.web.ts
+++ b/packages/react-native-mmkv/src/createMMKV/createMMKV.web.ts
@@ -39,7 +39,16 @@ export function createMMKV(
 
   return {
     id: config.id,
-    size: 0,
+    get length(): number {
+      return getLocalStorage().length
+    },
+    get size(): number {
+      return this.byteSize
+    },
+    get byteSize(): number {
+      // esimate - assumes UTF8
+      return JSON.stringify(getLocalStorage()).length
+    },
     isReadOnly: false,
     isEncrypted: false,
     clearAll: () => {

--- a/packages/react-native-mmkv/src/createMMKV/createMockMMKV.ts
+++ b/packages/react-native-mmkv/src/createMMKV/createMockMMKV.ts
@@ -18,8 +18,15 @@ export function createMockMMKV(
 
   return {
     id: config.id,
-    get size(): number {
+    get length(): number {
       return storage.size
+    },
+    get size(): number {
+      return this.byteSize
+    },
+    get byteSize(): number {
+      // esimate - assumes UTF8
+      return JSON.stringify(storage).length
     },
     isReadOnly: false,
     isEncrypted: false,

--- a/packages/react-native-mmkv/src/specs/MMKV.nitro.ts
+++ b/packages/react-native-mmkv/src/specs/MMKV.nitro.ts
@@ -11,11 +11,21 @@ export interface MMKV extends HybridObject<{ ios: 'c++'; android: 'c++' }> {
    */
   readonly id: string
   /**
+   * Get the current amount of key/value pairs stored in
+   * this storage.
+   */
+  readonly length: number
+  /**
    * Get the current total size of the storage, in bytes.
+   * @deprecated Use {@linkcode byteSize} instead.
    */
   readonly size: number
   /**
-   * Returns whether this instance is in read-only mode or not.
+   * Get the current total size of the storage, in bytes.
+   */
+  readonly byteSize: number
+  /**
+   * Get whether this instance is in read-only mode or not.
    * If this is `true`, you can only use "get"-functions.
    */
   readonly isReadOnly: boolean


### PR DESCRIPTION
- Adds a `.length` property that specifies the number of key/value pairs in the MMKV storage instance
- Adds a `.byteSize` property that specifies the number of bytes stored in the MMKV storage instance
- Deprecates `.size` in favor of `.byteSize`, and to avoid confusion with `.length`