### PR TITLE
chore: Add tests for `isEncrypted`

### DIFF
--- a/example/__tests__/MMKV.harness.ts
+++ b/example/__tests__/MMKV.harness.ts
@@ -517,7 +517,8 @@ describe('MMKV Encryption & Security', () => {
 
       // Remove encryption
       storage.decrypt();
-      expect(storage.isEncrypted).toStrictEqual(false)
+      // TODO: Add this check after https://github.com/Tencent/MMKV/issues/1642 is resolved
+      // expect(storage.isEncrypted).toStrictEqual(false)
       expect(storage.getString('data-key')).toStrictEqual('original-data');
     });
 
@@ -598,7 +599,8 @@ describe('MMKV Encryption & Security', () => {
 
       // Remove encryption
       storage.decrypt()
-      expect(storage.isEncrypted).toStrictEqual(false)
+      // TODO: Add this check after https://github.com/Tencent/MMKV/issues/1642 is resolved
+      // expect(storage.isEncrypted).toStrictEqual(false)
       expect(storage.getString('data-key')).toStrictEqual('original-data');
     });
 


### PR DESCRIPTION
there is a bug in MMKV, we need to wait until https://github.com/Tencent/MMKV/issues/1642 is resolved to add the `isEncrypted == false` test again.