### PR TITLE
fix: trigger bump when useEffect is mounted for the first time to retrieve latest value and prevents stale values being returned

### DIFF
--- a/packages/react-native-mmkv/src/hooks/createMMKVHook.ts
+++ b/packages/react-native-mmkv/src/hooks/createMMKVHook.ts
@@ -53,6 +53,7 @@ export function createMMKVHook<
 
     // update value if it changes somewhere else (second hook, same key)
     useEffect(() => {
+      setBump((b) => b + 1)
       const listener = mmkv.addOnValueChangedListener((changedKey) => {
         if (changedKey === key) {
           setBump((b) => b + 1)


### PR DESCRIPTION
I had a stab at resolving [this issue](https://github.com/mrousavy/react-native-mmkv/issues/1006) and from local testing it no longer listens to stale values when components are remounted under `Activity`