### PR TITLE
fix: Use `useSyncExternalStore()` for hooks

### DIFF
--- a/packages/react-native-mmkv/src/__tests__/hooks.test.tsx
+++ b/packages/react-native-mmkv/src/__tests__/hooks.test.tsx
@@ -94,7 +94,6 @@ test('functional updates to hooks', () => {
   ])
 })
 
-
 test('useMMKV hook does not miss updates that happen during subscription setup', async () => {
   const raceKey = 'race-key'
   const raceMMKV = createMMKV()

--- a/packages/react-native-mmkv/src/hooks/createMMKVHook.ts
+++ b/packages/react-native-mmkv/src/hooks/createMMKVHook.ts
@@ -25,8 +25,8 @@ export function createMMKVHook<
         },
         [key, mmkv]
       ),
-      useCallback(() => getter(mmkv, key), [getter, key, mmkv]),
-      useCallback(() => getter(mmkv, key), [getter, key, mmkv])
+      useCallback(() => getter(mmkv, key), [key, mmkv]),
+      useCallback(() => getter(mmkv, key), [key, mmkv])
     )
 
     // update value by user set


### PR DESCRIPTION
### Motivation
- Replace the previous `useEffect` + `bump` refresh workaround with `useSyncExternalStore` so hook updates are driven by MMKV key-change subscriptions and integrate correctly with React's rendering model.

### Description
- Replaced `useEffect`/`useState`/`useMemo` read/update logic in `packages/react-native-mmkv/src/hooks/createMMKVHook.ts` with `useSyncExternalStore` and a `subscribe` callback that calls `onStoreChange()` when the watched key changes, while preserving the existing setter behavior and added an explicit type for the `onStoreChange` parameter.

### Testing
- Ran `bun --cwd packages/react-native-mmkv typecheck`, which failed in this environment due to missing workspace dependencies/type declarations for `react`, `react-native`, and testing globals, so the failure is environmental and not indicative of this hook change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c3aaf3664832bb4c93de9628537e3)