### PR TITLE
chore: Test iOS build CI on generic iOS Simulator

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -30,6 +30,8 @@ on:
 
 env:
   USE_CCACHE: 1
+  # Must match the runner's architecture (macOS-15 runners are arm64)
+  ARCH: arm64
 
 jobs:
   build:
@@ -75,6 +77,6 @@ jobs:
           -scheme MmkvExample \
           -sdk iphonesimulator \
           -configuration Debug \
-          -destination 'generic/platform=iOS Simulator' \
+          -destination 'generic/platform=iOS Simulator,arch=${{ env.ARCH }}' \
           build \
           CODE_SIGNING_ALLOWED=NO"


### PR DESCRIPTION
Fixes errors like these:

```
Run set -o pipefail && xcodebuild CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ -derivedDataPath build -UseModernBuildSystem=YES -workspace MmkvExample.xcworkspace -scheme MmkvExample -sdk iphonesimulator -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 16' build CODE_SIGNING_ALLOWED=NO
Command line invocation:
    /Applications/Xcode_16.4.app/Contents/Developer/usr/bin/xcodebuild CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ -derivedDataPath build -UseModernBuildSystem=YES -workspace MmkvExample.xcworkspace -scheme MmkvExample -sdk iphonesimulator -configuration Debug -destination "platform=iOS Simulator,name=iPhone 16" build CODE_SIGNING_ALLOWED=NO
Build settings from command line:
    CC = clang
    CODE_SIGNING_ALLOWED = NO
    CPLUSPLUS = clang++
    LD = clang
    LDPLUSPLUS = clang++
    SDKROOT = iphonesimulator18.5
2026-03-20 15:45:40.648 xcodebuild[30225:83563] Writing error result bundle to /var/folders/t5/f77_gwnj6p95qxy9py3fckx00000gn/T/ResultBundle_2026-20-03_15-45-0040.xcresult
xcodebuild: error: Unable to find a device matching the provided destination specifier:
		{ platform:iOS Simulator, OS:latest, name:iPhone 16 }
	The requested device could not be found because no available devices matched the request.
	Available destinations for the "MmkvExample" scheme:
		{ platform:macOS, arch:arm64, variant:Designed for [iPad,iPhone], id:0c07f4508fe6f422118c9de8e5eee40a8ebb9093, name:My Mac }
		{ platform:iOS, id:dvtdevice-DVTiPhonePlaceholder-iphoneos:placeholder, name:Any iOS Device }
		{ platform:iOS Simulator, id:dvtdevice-DVTiOSDeviceSimulatorPlaceholder-iphonesimulator:placeholder, name:Any iOS Simulator Device }
Error: Process completed with exit code 70.
```