### PR TITLE
fix(android): replace deprecated TurboReactPackage with BaseReactPackage

### DIFF
--- a/packages/react-native-mmkv/android/src/main/java/com/margelo/nitro/mmkv/NitroMmkvPackage.java
+++ b/packages/react-native-mmkv/android/src/main/java/com/margelo/nitro/mmkv/NitroMmkvPackage.java
@@ -7,13 +7,13 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.module.model.ReactModuleInfoProvider;
-import com.facebook.react.TurboReactPackage;
+import com.facebook.react.BaseReactPackage;
 import com.margelo.nitro.core.HybridObject;
 
 import java.util.HashMap;
 import java.util.function.Supplier;
 
-public class NitroMmkvPackage extends TurboReactPackage {
+public class NitroMmkvPackage extends BaseReactPackage {
   @Nullable
   @Override
   public NativeModule getModule(String name, ReactApplicationContext reactContext) {


### PR DESCRIPTION
`NitroMmkvPackage` extends `TurboReactPackage`, which is deprecated and causes a crash in a React Native 0.80 app.