### PR TITLE
feat: add expo config plugin for mmkv log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,21 @@ If a user chooses to disable LocalStorage in their browser, the library will aut
 
 ## Integrations
 
+#### Expo
+
+If you use Expo Prebuild or EAS Build, configure the log level through the config plugin:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      ["react-native-mmkv", { "logLevel": 4 }]
+    ]
+  }
+}
+```
+
+
 ### Rozenite
 
 Use [@rozenite/mmkv-plugin](https://www.rozenite.dev/docs/official-plugins/mmkv) to debug your MMKV storage using Rozenite.

--- a/packages/react-native-mmkv/app.plugin.js
+++ b/packages/react-native-mmkv/app.plugin.js
@@ -1,0 +1,87 @@
+const {
+  createRunOncePlugin,
+  withGradleProperties,
+  withPodfile,
+} = require('@expo/config-plugins')
+const pkg = require('./package.json')
+
+const ANDROID_LOG_LEVEL_PROPERTY = 'MMKV_logLevel'
+const IOS_LOG_LEVEL_VARIABLE = '$MMKVLogLevel'
+
+function normalizeLogLevel(logLevel) {
+  if (logLevel == null) {
+    return null
+  }
+
+  if (typeof logLevel === 'string' && logLevel.trim() === '') {
+    throw new Error('react-native-mmkv: logLevel must be an integer between 0 and 4.')
+  }
+
+  const value = Number(logLevel)
+
+  if (!Number.isInteger(value) || value < 0 || value > 4) {
+    throw new Error('react-native-mmkv: logLevel must be an integer between 0 and 4.')
+  }
+
+  return String(value)
+}
+
+function setGradleProperty(properties, key, value) {
+  const existing = properties.find(
+    (item) => item.type === 'property' && item.key === key
+  )
+
+  if (existing != null) {
+    existing.value = value
+  } else {
+    properties.push({
+      type: 'property',
+      key,
+      value,
+    })
+  }
+
+  return properties
+}
+
+function setPodfileVariable(contents, value) {
+  const line = `${IOS_LOG_LEVEL_VARIABLE} = ${value}`
+  const pattern = /^\s*\$MMKVLogLevel\s*=.*$/m
+
+  if (pattern.test(contents)) {
+    return contents.replace(pattern, line)
+  }
+
+  return `${line}\n${contents}`
+}
+
+function withMMKV(config, props = {}) {
+  const logLevel = normalizeLogLevel(props.logLevel)
+
+  if (logLevel == null) {
+    return config
+  }
+
+  config = withGradleProperties(config, (config) => {
+    config.modResults = setGradleProperty(
+      config.modResults,
+      ANDROID_LOG_LEVEL_PROPERTY,
+      logLevel
+    )
+
+    return config
+  })
+
+  config = withPodfile(config, (config) => {
+    config.modResults.contents = setPodfileVariable(
+      config.modResults.contents,
+      logLevel
+    )
+
+    return config
+  })
+
+  return config
+}
+
+module.exports = createRunOncePlugin(withMMKV, pkg.name, pkg.version)


### PR DESCRIPTION
adds expo config plugin support for configuring mmkv native log level during prebuild

mmkv already supports build time log level configuration through

android:
```
MMKV_logLevel in android/gradle.properties
```

iOS:
```
$MMKVLogLevel in ios/Podfile
```

https://github.com/mrousavy/react-native-mmkv/pull/995

expo users should not manually edit generated native files, so this exposes the existing native configuration through the package config plugin

```app.json
[
  "react-native-mmkv",
  {
    "logLevel": 4
  }
]
```