### PR TITLE
fix: fix `length` incorrect in MMKV Web

### DIFF
--- a/packages/react-native-mmkv/src/createMMKV/createMMKV.web.ts
+++ b/packages/react-native-mmkv/src/createMMKV/createMMKV.web.ts
@@ -42,7 +42,13 @@ export function createMMKV(
   return {
     id: config.id,
     get length(): number {
-      return getLocalStorage().length
+      const storage = getLocalStorage()
+      let count = 0
+      for (let i = 0; i < storage.length; i++) {
+        const key = storage.key(i)
+        if (key != null && key.startsWith(keyPrefix)) count++
+      }
+      return count
     },
     get size(): number {
       return this.byteSize


### PR DESCRIPTION
`localstorage.length` returns all the length even those that were not set by MMKV