### PR TITLE
chore: Upgrade Nitro to 0.35.9

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "react-native-mmkv-monorepo",
@@ -26,7 +27,7 @@
         "react-dom": "19.1.1",
         "react-native": "0.82.0",
         "react-native-mmkv": "*",
-        "react-native-nitro-modules": "0.35.0",
+        "react-native-nitro-modules": "0.35.9",
         "react-native-safe-area-context": "^5.5.2",
         "react-native-web": "~0.21.0",
       },
@@ -68,11 +69,11 @@
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
-        "nitrogen": "0.35.0",
+        "nitrogen": "0.35.9",
         "prettier": "^3.3.3",
         "react": "19.1.1",
         "react-native": "0.82.0",
-        "react-native-nitro-modules": "0.35.0",
+        "react-native-nitro-modules": "0.35.9",
         "typescript": "^5.8.3",
       },
       "peerDependencies": {
@@ -635,7 +636,7 @@
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
-    "@ts-morph/common": ["@ts-morph/common@0.28.1", "", { "dependencies": { "minimatch": "^10.0.1", "path-browserify": "^1.0.1", "tinyglobby": "^0.2.14" } }, "sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g=="],
+    "@ts-morph/common": ["@ts-morph/common@0.29.0", "", { "dependencies": { "minimatch": "^10.0.1", "path-browserify": "^1.0.1", "tinyglobby": "^0.2.14" } }, "sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
@@ -1675,7 +1676,7 @@
 
     "new-github-release-url": ["new-github-release-url@2.0.0", "", { "dependencies": { "type-fest": "^2.5.1" } }, "sha512-NHDDGYudnvRutt/VhKFlX26IotXe1w0cmkDm6JGquh5bz/bDTw0LufSmH/GxTjEdpHEO+bVKFTwdrcGa/9XlKQ=="],
 
-    "nitrogen": ["nitrogen@0.35.0", "", { "dependencies": { "chalk": "^5.3.0", "react-native-nitro-modules": "^0.35.0", "ts-morph": "^27.0.0", "yargs": "^18.0.0", "zod": "^4.0.5" }, "bin": { "nitrogen": "lib/index.js" } }, "sha512-K8/4h9bCQahi3qEheWZx5joLFsAW3QjK0dVSC3gNLlQhlSJN42UFmffAouOZXYjg9rBDpVlrVo+Hsja45swsJQ=="],
+    "nitrogen": ["nitrogen@0.35.9", "", { "dependencies": { "chalk": "^5.3.0", "react-native-nitro-modules": "^0.35.9", "ts-morph": "^28.0.0", "yargs": "^18.0.0", "zod": "^4.0.5" }, "bin": { "nitrogen": "lib/index.js" } }, "sha512-Qbs45N/9VXYFg4u/nUF4EKw7qmbaVD0vABh5Rq6e3YT1MQP672/EBneMfNXvwOaTf8KW3pIxM01IlEdKS3f8JQ=="],
 
     "nocache": ["nocache@3.0.4", "", {}, "sha512-WDD0bdg9mbq6F4mRxEYcPWwfA1vxd0mrvKOyxI7Xj/atfRHVeutzuWByG//jfm4uPzp0y4Kj051EORCBSQMycw=="],
 
@@ -1859,7 +1860,7 @@
 
     "react-native-mmkv": ["react-native-mmkv@workspace:packages/react-native-mmkv"],
 
-    "react-native-nitro-modules": ["react-native-nitro-modules@0.35.0", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-Eho1yEcLbsteGpBFn2XZOp5FIptnEciWzuYBW49S0jo41Un2LeyesIO/MqYLY/c5o7D9Fw9th4pxGtV7OAb0+g=="],
+    "react-native-nitro-modules": ["react-native-nitro-modules@0.35.9", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-yCO6eJ85SPPUo4a4an7H5oj6wPCSIT72fbjr5WZ/20n6zswaJ2gNNpnWtg2We0AZwkAOjSqkOJ0Vjc05p6kGiA=="],
 
     "react-native-safe-area-context": ["react-native-safe-area-context@5.6.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-/wJE58HLEAkATzhhX1xSr+fostLsK8Q97EfpfMDKo8jlOc1QKESSX/FQrhk7HhQH/2uSaox4Y86sNaI02kteiA=="],
 
@@ -2091,7 +2092,7 @@
 
     "ts-api-utils": ["ts-api-utils@2.1.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ=="],
 
-    "ts-morph": ["ts-morph@27.0.2", "", { "dependencies": { "@ts-morph/common": "~0.28.1", "code-block-writer": "^13.0.3" } }, "sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w=="],
+    "ts-morph": ["ts-morph@28.0.0", "", { "dependencies": { "@ts-morph/common": "~0.29.0", "code-block-writer": "^13.0.3" } }, "sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -40,7 +40,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - NitroModules (0.35.0):
+  - NitroModules (0.35.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2721,8 +2721,8 @@ SPEC CHECKSUMS:
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 8642d8f14a548ab718ec112e9bebdfdd154138b5
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
-  NitroMmkv: ef2074caf812c4e421ff5cfd61ddec2d9d520fea
-  NitroModules: 0ffbade1b2ebcfa12f3821c970b17fa369320810
+  NitroMmkv: b3c3796dc39694841179bbac905b7c0e479e805f
+  NitroModules: d7c4d6ca3743ae69010aa63b67d3bf0f9f5e7b63
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: 22bf66112da540a7d40e536366ddd8557934fca1
   RCTRequired: a0ed4dc41b35f79fbb6d8ba320e06882a8c792cf
@@ -2790,8 +2790,8 @@ SPEC CHECKSUMS:
   ReactCodegen: e375232a1c06c655f2ec80519d0b344e133b5475
   ReactCommon: 17f21c8e189e290113e40fd8652758ec9694897b
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: edeb9900b9e5bb5b27b9a6a2d5914e4fe4033c1b
+  Yoga: 93bc00d78638987f9ffd928f4a9f895d3e601bc3
 
-PODFILE CHECKSUM: 552d9b4ad2f0e8b724ec8f64e95b04337deac920
+PODFILE CHECKSUM: ac6e3a3935879b4d187353a98679212e0e3604ce
 
 COCOAPODS: 1.15.2

--- a/example/package.json
+++ b/example/package.json
@@ -24,7 +24,7 @@
     "http-proxy": "^1.18.1",
     "react-dom": "19.1.1",
     "react-native-mmkv": "*",
-    "react-native-nitro-modules": "0.35.0",
+    "react-native-nitro-modules": "0.35.9",
     "react-native-safe-area-context": "^5.5.2",
     "react-native-web": "~0.21.0"
   },

--- a/packages/react-native-mmkv/nitro.json
+++ b/packages/react-native-mmkv/nitro.json
@@ -14,11 +14,20 @@
   },
   "autolinking": {
     "MMKVFactory": {
-      "cpp": "HybridMMKVFactory"
+      "all": {
+        "language": "c++",
+        "implementationClassName": "HybridMMKVFactory"
+      }
     },
     "MMKVPlatformContext": {
-      "swift": "HybridMMKVPlatformContext",
-      "kotlin": "HybridMMKVPlatformContext"
+      "ios": {
+        "language": "swift",
+        "implementationClassName": "HybridMMKVPlatformContext"
+      },
+      "android": {
+        "language": "kotlin",
+        "implementationClassName": "HybridMMKVPlatformContext"
+      }
     }
   },
   "ignorePaths": [

--- a/packages/react-native-mmkv/nitrogen/generated/android/NitroMmkvOnLoad.cpp
+++ b/packages/react-native-mmkv/nitrogen/generated/android/NitroMmkvOnLoad.cpp
@@ -28,9 +28,9 @@ int initialize(JavaVM* vm) {
 }
 
 struct JHybridMMKVPlatformContextSpecImpl: public jni::JavaClass<JHybridMMKVPlatformContextSpecImpl, JHybridMMKVPlatformContextSpec::JavaPart> {
-  static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/mmkv/HybridMMKVPlatformContext;";
+  static constexpr auto kJavaDescriptor = "Lcom/margelo/nitro/mmkv/HybridMMKVPlatformContext;";
   static std::shared_ptr<JHybridMMKVPlatformContextSpec> create() {
-    static auto constructorFn = javaClassStatic()->getConstructor<JHybridMMKVPlatformContextSpecImpl::javaobject()>();
+    static const auto constructorFn = javaClassStatic()->getConstructor<JHybridMMKVPlatformContextSpecImpl::javaobject()>();
     jni::local_ref<JHybridMMKVPlatformContextSpec::JavaPart> javaPart = javaClassStatic()->newObject(constructorFn);
     return javaPart->getJHybridMMKVPlatformContextSpec();
   }

--- a/packages/react-native-mmkv/nitrogen/generated/android/c++/JHybridMMKVPlatformContextSpec.hpp
+++ b/packages/react-native-mmkv/nitrogen/generated/android/c++/JHybridMMKVPlatformContextSpec.hpp
@@ -21,11 +21,11 @@ namespace margelo::nitro::mmkv {
   class JHybridMMKVPlatformContextSpec: public virtual HybridMMKVPlatformContextSpec, public virtual JHybridObject {
   public:
     struct JavaPart: public jni::JavaClass<JavaPart, JHybridObject::JavaPart> {
-      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/mmkv/HybridMMKVPlatformContextSpec;";
+      static constexpr auto kJavaDescriptor = "Lcom/margelo/nitro/mmkv/HybridMMKVPlatformContextSpec;";
       std::shared_ptr<JHybridMMKVPlatformContextSpec> getJHybridMMKVPlatformContextSpec();
     };
     struct CxxPart: public jni::HybridClass<CxxPart, JHybridObject::CxxPart> {
-      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/mmkv/HybridMMKVPlatformContextSpec$CxxPart;";
+      static constexpr auto kJavaDescriptor = "Lcom/margelo/nitro/mmkv/HybridMMKVPlatformContextSpec$CxxPart;";
       static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
       static void registerNatives();
       using HybridBase::HybridBase;

--- a/packages/react-native-mmkv/nitrogen/generated/ios/NitroMmkv+autolinking.rb
+++ b/packages/react-native-mmkv/nitrogen/generated/ios/NitroMmkv+autolinking.rb
@@ -56,5 +56,7 @@ def add_nitrogen_files(spec)
     "SWIFT_OBJC_INTEROP_MODE" => "objcxx",
     # Enables stricter modular headers
     "DEFINES_MODULE" => "YES",
+    # Disable auto-generated ObjC header for Swift (Static linkage on Xcode 26.4 breaks here)
+    "SWIFT_INSTALL_OBJC_HEADER" => "NO",
   })
 end

--- a/packages/react-native-mmkv/package.json
+++ b/packages/react-native-mmkv/package.json
@@ -67,11 +67,11 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
-    "nitrogen": "0.35.0",
+    "nitrogen": "0.35.9",
     "prettier": "^3.3.3",
     "react": "19.1.1",
     "react-native": "0.82.0",
-    "react-native-nitro-modules": "0.35.0",
+    "react-native-nitro-modules": "0.35.9",
     "typescript": "^5.8.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

- Upgrades `nitrogen` and `react-native-nitro-modules` from 0.35.0 to 0.35.9.
- Regenerates Nitro outputs with the 0.35.9 generator.
- Migrates `nitro.json` autolinking entries from the deprecated `cpp`/`swift`/`kotlin` shorthand to the current `all`/`ios`/`android` shape.
- Refreshes `Podfile.lock` so the example resolves `NitroModules` 0.35.9.

## Notes

The new generator emits `SWIFT_INSTALL_OBJC_HEADER = NO` for the generated iOS pod settings, which matches the upstream Xcode 26.4 static-linkage fix.

## Validation

- `bun mmkv specs`
- `bun typecheck`
- `bun run test`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew assembleDebug --no-daemon --build-cache` from `example/android`

`bun test` was also tried first and failed intentionally because the repo guards against using Bun's test runner directly; `bun run test` is the valid Jest path.