### PR TITLE
chore: Upgrade react-native-safe-area-context to 5.8.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
         "react-native": "0.85.3",
         "react-native-mmkv": "*",
         "react-native-nitro-modules": "0.35.9",
-        "react-native-safe-area-context": "^5.5.2",
+        "react-native-safe-area-context": "^5.8.0",
         "react-native-web": "~0.21.0",
       },
       "devDependencies": {
@@ -1985,7 +1985,7 @@
 
     "react-native-nitro-modules": ["react-native-nitro-modules@0.35.9", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-yCO6eJ85SPPUo4a4an7H5oj6wPCSIT72fbjr5WZ/20n6zswaJ2gNNpnWtg2We0AZwkAOjSqkOJ0Vjc05p6kGiA=="],
 
-    "react-native-safe-area-context": ["react-native-safe-area-context@5.6.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-/wJE58HLEAkATzhhX1xSr+fostLsK8Q97EfpfMDKo8jlOc1QKESSX/FQrhk7HhQH/2uSaox4Y86sNaI02kteiA=="],
+    "react-native-safe-area-context": ["react-native-safe-area-context@5.8.0", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-t+ZsAVzY/wWzzx34vqGbo3/as9EEESJdbyZNL7Yg5EYX+toYMtMqFoDDCvqZUi35eeGVsXc6pAaEk4edMwbuCQ=="],
 
     "react-native-url-polyfill": ["react-native-url-polyfill@3.0.0", "", { "dependencies": { "whatwg-url-without-unicode": "8.0.0-3" }, "peerDependencies": { "react-native": "*" } }, "sha512-aA5CiuUCUb/lbrliVCJ6lZ17/RpNJzvTO/C7gC/YmDQhTUoRD5q5HlJfwLWcxz4VgAhHwXKzhxH+wUN24tAdqg=="],
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1451,7 +1451,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-safe-area-context (5.6.1):
+  - react-native-safe-area-context (5.8.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1463,8 +1463,8 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-safe-area-context/common (= 5.6.1)
-    - react-native-safe-area-context/fabric (= 5.6.1)
+    - react-native-safe-area-context/common (= 5.8.0)
+    - react-native-safe-area-context/fabric (= 5.8.0)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -1475,7 +1475,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-safe-area-context/common (5.6.1):
+  - react-native-safe-area-context/common (5.8.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1497,7 +1497,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-safe-area-context/fabric (5.6.1):
+  - react-native-safe-area-context/fabric (5.8.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2191,7 +2191,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 1aa9126122d4247ffc24bf9d28d50ce923499a71
   React-microtasksnativemodule: d86581169e9bb5bb6f5fc3c5052f890016c1bf21
   React-mutationobservernativemodule: 9a0c4e866f1ef2a57acebc902ebacbdf469ae741
-  react-native-safe-area-context: 650ba9c4c3ce2d68bbd7c450d08b7250c7b58623
+  react-native-safe-area-context: c1eb308f4b36372a4de4b3bdaa8ed695ec3dd461
   React-NativeModulesApple: cc6ec4767844d610e92cc358bd3ea34937438d56
   React-networking: a8ce15641ed7775d5b54a9d0d32defc367c2216e
   React-oscompat: 64a0c7ef5441855dc6e2a6afe8ba8f92aa05075e
@@ -2226,7 +2226,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 7862b98c16d5497b7c56c4821a64446a9dacddf2
   ReactCommon: 3ec2a55999d296af90c24beb66c8a77dc660d3ef
   ReactNativeDependencies: 93ae3057006336cc4a9caf4053c595d887094a1e
-  Yoga: 36fee8f1fca3f54a28c3d7f80e69f66d73d3af96
+  Yoga: 77dfa8673de2874e1855002ae59c68b8be9b007b
 
 PODFILE CHECKSUM: ac6e3a3935879b4d187353a98679212e0e3604ce
 

--- a/example/package.json
+++ b/example/package.json
@@ -24,7 +24,7 @@
     "react-dom": "19.2.6",
     "react-native-mmkv": "*",
     "react-native-nitro-modules": "0.35.9",
-    "react-native-safe-area-context": "^5.5.2",
+    "react-native-safe-area-context": "^5.8.0",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Upgrade the example app's `react-native-safe-area-context` dependency to `^5.8.0`.
- Refresh `bun.lock` and `example/ios/Podfile.lock` so the iOS pods resolve `react-native-safe-area-context` 5.8.0.
- CocoaPods also corrected stale Yoga and Podfile checksums while updating the lockfile; no Podfile or Yoga version change is included.

## Notes
- The 5.8.0 Android pod/package metadata removes the manifest namespace warning seen on 5.6.1.
- Android still emits React Native API deprecation warnings from safe-area internals; those are upstream compatibility warnings and not required for this bump.

## Validation
- `bun install`
- `rbenv exec bundle exec pod update react-native-safe-area-context hermes-engine --no-repo-update`
- `rbenv exec bundle exec pod install`
- `bun typecheck`
- `bun lint-ci`
- `bun run test`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew assembleDebug --no-daemon --build-cache`
- `xcodebuild CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ -derivedDataPath build -UseModernBuildSystem=YES -workspace MmkvExample.xcworkspace -scheme MmkvExample -sdk iphonesimulator -configuration Debug -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO`
- `git diff --check`