### PR TITLE
chore: Upgrade Kotlin to 2.3.21

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         compileSdkVersion = 36
         targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
-        kotlinVersion = "2.1.20"
+        kotlinVersion = "2.3.21"
     }
     repositories {
         google()
@@ -14,7 +14,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
     }
 }
 

--- a/packages/react-native-mmkv/android/gradle.properties
+++ b/packages/react-native-mmkv/android/gradle.properties
@@ -1,4 +1,4 @@
-NitroMmkv_kotlinVersion=2.1.20
+NitroMmkv_kotlinVersion=2.3.21
 NitroMmkv_minSdkVersion=23
 NitroMmkv_targetSdkVersion=36
 NitroMmkv_compileSdkVersion=36


### PR DESCRIPTION
## Summary
- Upgrade the example Android Kotlin version from `2.1.20` to `2.3.21`.
- Upgrade the library Android `NitroMmkv_kotlinVersion` default from `2.1.20` to `2.3.21`.
- Pin the app buildscript Kotlin Gradle plugin classpath to `$kotlinVersion` so transitive Android libraries compile with the same compiler version as the stdlib.

## Notes
- Kotlin `2.3.21` is the latest stable Maven release; `2.4.0` is currently RC and was intentionally not used.
- Without the explicit Kotlin Gradle plugin classpath version, the RN 0.82 Gradle plugin path kept a 2.1 compiler while dependencies resolved Kotlin 2.3 stdlib, causing metadata-version failures in `react-native-safe-area-context`.
- Kotlin 2.3.20/2.3.21 include Gradle 9.3 compatibility and Kotlin/JVM build tooling changes, but this repo does not use the affected Kotlin/Native/Wasm features.

## Validation
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew assembleDebug --no-daemon --build-cache`
- `bun typecheck`
- `bun run test`
- `git diff --check`