### PR TITLE
chore: Upgrade NDK to 29.0.14206865

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         minSdkVersion = 24
         compileSdkVersion = 36
         targetSdkVersion = 36
-        ndkVersion = "27.1.12297006"
+        ndkVersion = "29.0.14206865"
         kotlinVersion = "2.3.21"
     }
     repositories {

--- a/packages/react-native-mmkv/android/gradle.properties
+++ b/packages/react-native-mmkv/android/gradle.properties
@@ -2,4 +2,4 @@ NitroMmkv_kotlinVersion=2.3.21
 NitroMmkv_minSdkVersion=23
 NitroMmkv_targetSdkVersion=36
 NitroMmkv_compileSdkVersion=36
-NitroMmkv_ndkVersion=27.1.12297006
+NitroMmkv_ndkVersion=29.0.14206865


### PR DESCRIPTION
## Summary
- Upgrade the example Android NDK pin from `27.1.12297006` to `29.0.14206865`.
- Upgrade the library Android default `NitroMmkv_ndkVersion` to the same NDK r29 build.

## Notes
- Android SDK platform and build tools are already on the current stable API 36 / Build Tools 36.0.0, so this PR only changes NDK.
- NDK r29 is the current stable branch; the repo's native CMake targets build successfully with it.

## Validation
- `yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install "ndk;29.0.14206865"`
- `$ANDROID_HOME/ndk/29.0.14206865/ndk-build --version`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew assembleDebug --no-daemon --build-cache`
- `bun typecheck`
- `git diff --check`