### PR TITLE
chore: Upgrade iOS CI to Xcode 26.5

### DIFF
--- a/.github/workflows/build-ios-release.yml
+++ b/.github/workflows/build-ios-release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build_release:
     name: Build iOS Example App (release, new architecture)
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
@@ -28,8 +28,8 @@ jobs:
           bundler-cache: true
           working-directory: example
 
-      - name: Select Xcode 16.4
-        run: sudo xcode-select -s "/Applications/Xcode_16.4.app/Contents/Developer"
+      - name: Select Xcode 26.5
+        run: sudo xcode-select -s "/Applications/Xcode_26.5.app/Contents/Developer"
 
       - name: Restore Pods cache
         uses: actions/cache@v5

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -34,7 +34,7 @@ env:
 jobs:
   build:
     name: Build iOS Example App
-    runs-on: macOS-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
@@ -52,8 +52,8 @@ jobs:
           bundler-cache: true
           working-directory: example
 
-      - name: Select Xcode 26.2
-        run: sudo xcode-select -s "/Applications/Xcode_26.2.app/Contents/Developer"
+      - name: Select Xcode 26.5
+        run: sudo xcode-select -s "/Applications/Xcode_26.5.app/Contents/Developer"
 
       - name: Restore Pods cache
         uses: actions/cache@v5

--- a/.github/workflows/harness-ios.yml
+++ b/.github/workflows/harness-ios.yml
@@ -6,17 +6,17 @@ on:
       device_model:
         description: "iOS Simulator device model"
         required: false
-        default: "iPhone 16 Pro"
+        default: "iPhone 17 Pro"
         type: string
       ios_version:
         description: "iOS version"
         required: false
-        default: "18.6"
+        default: "26.5"
         type: string
       xcode_version:
         description: "Xcode version"
         required: false
-        default: "26.2.0"
+        default: "26.5.0"
         type: string
   push:
     branches:
@@ -51,16 +51,16 @@ on:
 
 env:
   # Device configuration - can be overridden by workflow_dispatch inputs
-  DEVICE_MODEL: ${{ github.event.inputs.device_model || 'iPhone 16 Pro' }}
-  IOS_VERSION: ${{ github.event.inputs.ios_version || '18.6' }}
-  XCODE_VERSION: ${{ github.event.inputs.xcode_version || '26.2.0' }}
+  DEVICE_MODEL: ${{ github.event.inputs.device_model || 'iPhone 17 Pro' }}
+  IOS_VERSION: ${{ github.event.inputs.ios_version || '26.5' }}
+  XCODE_VERSION: ${{ github.event.inputs.xcode_version || '26.5.0' }}
   USE_CCACHE: 1
-  DEVELOPER_DIR: /Applications/Xcode_${{ github.event.inputs.xcode_version || '26.2.0' }}.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_${{ github.event.inputs.xcode_version || '26.5.0' }}.app/Contents/Developer
 
 jobs:
   harness_ios_new:
     name: Harness iOS (new architecture)
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/harness-ios.yml
+++ b/.github/workflows/harness-ios.yml
@@ -119,5 +119,8 @@ jobs:
 
       - name: Run Harness E2E tests
         working-directory: example
+        env:
+          HARNESS_IOS_DEVICE: ${{ env.DEVICE_MODEL }}
+          HARNESS_IOS_VERSION: ${{ env.IOS_VERSION }}
         run: |
           bun run test:harness --harnessRunner ios

--- a/example/rn-harness.config.mjs
+++ b/example/rn-harness.config.mjs
@@ -29,8 +29,8 @@ const config = {
     applePlatform({
       name: 'ios',
       device: appleSimulator(
-        process.env.HARNESS_IOS_DEVICE ?? 'iPhone 16 Pro',
-        process.env.HARNESS_IOS_VERSION ?? '18.6'
+        process.env.HARNESS_IOS_DEVICE ?? 'iPhone 17 Pro',
+        process.env.HARNESS_IOS_VERSION ?? '26.5'
       ),
       bundleId: 'com.mrousavy.mmkv.example',
     }),


### PR DESCRIPTION
## Summary
- Move iOS build, release build, and iOS harness jobs to the `macos-26` GitHub runner image.
- Select Xcode 26.5 in iOS build workflows.
- Update the iOS harness defaults to an iOS 26.5 simulator/runtime that exists on the `macos-26` image.
- Keep the release asset upload release-only so pull-request validation can build/package without a release `upload_url`.

## Notes
- This PR is stacked on #1045 because RN 0.82's bundled fmt stack does not compile cleanly with Xcode 26.4+; RN 0.85 includes the upstream fmt update for that compiler family.
- GitHub's current `macos-latest` / `macos-15` image exposes Xcode up to 26.3, while `macos-26` exposes Xcode 26.5 and iOS 26.5 SDK/simulators.
- The harness default device changes from `iPhone 16 Pro` to `iPhone 17 Pro` because the `macos-26` image's iOS 26.5 simulator set includes the iPhone 17 generation.

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/build-ios.yml .github/workflows/harness-ios.yml .github/workflows/build-ios-release.yml`
- `git diff --check`