### PR TITLE
ci: Build iOS harness with generic simulator

### DIFF
--- a/.github/workflows/harness-ios.yml
+++ b/.github/workflows/harness-ios.yml
@@ -100,7 +100,7 @@ jobs:
           -scheme MmkvExample \
           -sdk iphonesimulator \
           -configuration Debug \
-          -destination 'platform=iOS Simulator,name=${{ env.DEVICE_MODEL }}' \
+          -destination 'generic/platform=iOS Simulator' \
           build \
           CODE_SIGNING_ALLOWED=NO"
 


### PR DESCRIPTION
## Summary
- Build the iOS harness app against a generic simulator destination.
- Keep the configured simulator model/runtime for the later boot/install/E2E test steps.

## Reason
Recent macOS images do not always expose the configured simulator as an available Xcode build destination before `futureware-tech/simulator-action` creates it. The app build does not need a named simulator, so this keeps the build independent of the E2E target device.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/harness-ios.yml"); puts "ok .github/workflows/harness-ios.yml"'`