### PR TITLE
chore: Use Gradle assignment syntax

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -73,35 +73,35 @@ def enableProguardInReleaseBuilds = false
 def jscFlavor = 'io.github.react-native-community:jsc-android:2026004.+'
 
 android {
-    ndkVersion rootProject.ext.ndkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
-    compileSdk rootProject.ext.compileSdkVersion
+    ndkVersion = rootProject.ext.ndkVersion
+    buildToolsVersion = rootProject.ext.buildToolsVersion
+    compileSdk = rootProject.ext.compileSdkVersion
 
-    namespace "com.mrousavy.mmkv.example"
+    namespace = "com.mrousavy.mmkv.example"
     defaultConfig {
-        applicationId "com.mrousavy.mmkv.example"
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        applicationId = "com.mrousavy.mmkv.example"
+        minSdkVersion = rootProject.ext.minSdkVersion
+        targetSdkVersion = rootProject.ext.targetSdkVersion
+        versionCode = 1
+        versionName = "1.0"
     }
     signingConfigs {
         debug {
-            storeFile file('debug.keystore')
-            storePassword 'android'
-            keyAlias 'androiddebugkey'
-            keyPassword 'android'
+            storeFile = file('debug.keystore')
+            storePassword = 'android'
+            keyAlias = 'androiddebugkey'
+            keyPassword = 'android'
         }
     }
     buildTypes {
         debug {
-            signingConfig signingConfigs.debug
+            signingConfig = signingConfigs.debug
         }
         release {
             // Caution! In production, you need to generate your own keystore file.
             // see https://reactnative.dev/docs/signed-apk-android.
-            signingConfig signingConfigs.debug
-            minifyEnabled enableProguardInReleaseBuilds
+            signingConfig = signingConfigs.debug
+            minifyEnabled = enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }

--- a/packages/react-native-mmkv/android/build.gradle
+++ b/packages/react-native-mmkv/android/build.gradle
@@ -36,14 +36,14 @@ def getExtOrIntegerDefault(name) {
 }
 
 android {
-  namespace "com.margelo.nitro.mmkv"
+  namespace = "com.margelo.nitro.mmkv"
 
-  ndkVersion getExtOrDefault("ndkVersion")
-  compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
+  ndkVersion = getExtOrDefault("ndkVersion")
+  compileSdkVersion = getExtOrIntegerDefault("compileSdkVersion")
 
   defaultConfig {
-    minSdkVersion getExtOrIntegerDefault("minSdkVersion")
-    targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
+    minSdkVersion = getExtOrIntegerDefault("minSdkVersion")
+    targetSdkVersion = getExtOrIntegerDefault("targetSdkVersion")
     buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
 
     externalNativeBuild {
@@ -71,7 +71,7 @@ android {
 
   externalNativeBuild {
     cmake {
-      path "CMakeLists.txt"
+      path = file("CMakeLists.txt")
     }
   }
 
@@ -98,13 +98,13 @@ android {
   }
 
   buildFeatures {
-    buildConfig true
-    prefab true
+    buildConfig = true
+    prefab = true
   }
 
   buildTypes {
     release {
-      minifyEnabled false
+      minifyEnabled = false
     }
   }
 
@@ -147,4 +147,3 @@ dependencies {
   // Add a dependency on mmkv core (this ships a C++ prefab)
   implementation "io.github.zhongwuzw:mmkv:2.4.0"
 }
-


### PR DESCRIPTION
## What changed
- Replaced deprecated Groovy space-assignment syntax with explicit `propName = value` assignments in the Android example app Gradle config.
- Applied the same cleanup to the MMKV package Android Gradle config for namespace, SDK, CMake path, build features, and release minification settings.

## Why
Gradle 9 warns that the generated Groovy setter syntax is deprecated and scheduled for removal in Gradle 10. The recent package/tooling upgrade made these warnings visible during Android builds.

## Impact
This is a syntax-only Gradle cleanup. It does not change app runtime behavior or dependency versions.

## Validation
- Confirmed `main` at `24f2e09` is green in GitHub Actions for Build Android, Build iOS, Harness Android, Harness iOS, Harness Web, Lint TypeScript, Run Nitrogen, and Test JS.
- Locally verified the upgraded app builds and launches on iOS and Android, with Metro serving `index.js`.
- Ran `JAVA_HOME=/opt/homebrew/opt/openjdk@17 ./gradlew app:assembleDebug -PreactNativeArchitectures=arm64-v8a --warning-mode all --no-daemon` successfully.
- Ran `git diff --check`.