### PR TITLE
perf: report MMKV external memory size

### DIFF
--- a/packages/react-native-mmkv/cpp/HybridMMKV.cpp
+++ b/packages/react-native-mmkv/cpp/HybridMMKV.cpp
@@ -82,6 +82,10 @@ double HybridMMKV::getByteSize() {
   return instance->actualSize();
 }
 
+size_t HybridMMKV::getExternalMemorySize() noexcept {
+  return instance != nullptr ? instance->actualSize() : 0;
+}
+
 bool HybridMMKV::getIsReadOnly() {
   return instance->isReadOnly();
 }

--- a/packages/react-native-mmkv/cpp/HybridMMKV.hpp
+++ b/packages/react-native-mmkv/cpp/HybridMMKV.hpp
@@ -44,6 +44,9 @@ public:
   Listener addOnValueChangedListener(const std::function<void(const std::string& /* key */)>& onValueChanged) override;
   double importAllFrom(const std::shared_ptr<HybridMMKVSpec>& other) override;
 
+protected:
+  size_t getExternalMemorySize() noexcept override;
+
 private:
   static MMKVMode getMMKVMode(const Configuration& config);
 


### PR DESCRIPTION
## Summary
- Override Nitro's `HybridObject::getExternalMemorySize()` in `HybridMMKV`.
- Report `MMKV::actualSize()` so Hermes/JSI receives a better external memory pressure signal for MMKV-backed native storage.

## Verification
- `bun run lint-cpp`
- `bun run typecheck`
- `cd example/android && ./gradlew :react-native-mmkv:externalNativeBuildRelease --no-daemon`

No Harness test added: external memory pressure is a GC hint applied through JSI and is not exposed as observable JS behavior.