### PR TITLE
docs: fix README object example comment and deprecated size usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ const user = {
 storage.set('user', JSON.stringify(user))
 
 // Deserialize the JSON string into an object
-const jsonUser = storage.getString('user') // { 'username': 'Marc', 'age': 21 }
-const userObject = JSON.parse(jsonUser)
+const jsonUser = storage.getString('user') // '{ "username": "Marc", "age": 21 }'
+const userObject = JSON.parse(jsonUser) // { username: 'Marc', age: 21 }
 ```
 
 ### Encryption
@@ -215,7 +215,7 @@ console.log(buffer) // [1, 100, 255]
 
 ```ts
 // get size of MMKV storage in bytes
-const size = storage.size
+const size = storage.byteSize
 if (size >= 4096) {
   // clean unused keys and clear memory cache
   storage.trim()


### PR DESCRIPTION
Two small fixes to the example snippets in the README.

### Objects example

```ts
const jsonUser = storage.getString('user') // { 'username': 'Marc', 'age': 21 }
const userObject = JSON.parse(jsonUser)
```

`getString` returns `string | undefined`, so the inline comment claiming an object value is misleading. It also contradicts the "Deserialize the JSON string into an object" line right above it. At that point the value is still the JSON string, and the parsed object only exists after `JSON.parse` on the next line. I relabeled the `getString` comment as the JSON string and moved the object comment down to the `JSON.parse` line.

### Size example

```ts
const size = storage.size
```

`size` is deprecated in favor of `byteSize` (see the JSDoc on the `size` getter in `MMKV.nitro.ts`), so the example now reads from `storage.byteSize`.
